### PR TITLE
[codex] Add long-form ingest skill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 ### Added
+- Added a new `knowledge-base-ingest` skill for splitting long markdown sources or books into reusable knowledge-base pages.
+- Added a deterministic heading-based splitter at `skills/knowledge-base-ingest/scripts/split_markdown.py`.
 - Generic example vault profile without personal local paths at `examples/example-vault-profile-generic.md`.
 - Basic GitHub Actions validation workflow for skill bundle structure and relative links.
 - Developer list updated to `邹星宇` and `杨琦` in the main repository surfaces.

--- a/COVER-CN.md
+++ b/COVER-CN.md
@@ -22,12 +22,14 @@
 
 ## 这个包里有什么
 
-### 3 个 skills
+### 4 个 skills
 1. `knowledge-base-kit-guide`
    - 安装说明 / 配置说明 / 技能分流
-2. `knowledge-base-maintenance`
+2. `knowledge-base-ingest`
+   - 把长 markdown / 书稿 / 教程拆分、链接并导入知识库
+3. `knowledge-base-maintenance`
    - 把任务结果沉淀进知识库
-3. `knowledge-base-audit`
+4. `knowledge-base-audit`
    - 审计知识库结构、导航、元数据和噪音回流
 
 ### 1 个配置模板
@@ -53,7 +55,7 @@
 1. 看 `START-HERE.md`
 2. 复制 `templates/vault-profile-template.md`
 3. 填你的 vault 路径、areas、root pages、frontmatter 规则
-4. 把 3 个 skills 复制到你的 skills 目录
+4. 把 4 个 skills 复制到你的 skills 目录
 5. 第一次先用 `knowledge-base-kit-guide`
 
 ### 如果你想先了解方法论
@@ -111,6 +113,13 @@
 先读 vault profile，再过滤过程噪音，按页面角色归类，并同步目标页、root page、reader entry 和 milestone log。
 ```
 
+### 想导入一本 markdown 书或长文档时可以说
+
+```text
+用 $knowledge-base-ingest 把这本 markdown 书导入我的知识库。
+先读 vault profile，再按章节/主题拆分，建立导航和 related links，并同步 overview、reader entry 和 milestone log。
+```
+
 ### 想做结构体检时可以说
 
 ```text
@@ -126,7 +135,7 @@
 
 ```text
 这是一个可复用的 wiki/markdown 知识库维护包。
-先看《中文封面说明页.md》或 START-HERE.md，再复制 3 个 skills，填 vault-profile-template.md，然后先用 knowledge-base-kit-guide 上手。
+先看《中文封面说明页.md》或 START-HERE.md，再复制 4 个 skills，填 vault-profile-template.md，然后先用 knowledge-base-kit-guide 上手。
 ```
 
 ---

--- a/DELIVERY-NOTES.md
+++ b/DELIVERY-NOTES.md
@@ -13,7 +13,7 @@
 
 ```text
 这是一个可复用的 wiki/markdown 知识库维护包。
-先看 START-HERE.md，再复制 3 个 skills，填好 vault-profile-template.md，然后先用 knowledge-base-kit-guide 上手。
+先看 START-HERE.md，再复制 4 个 skills，填好 vault-profile-template.md，然后先用 knowledge-base-kit-guide 上手。
 ```
 
 ## 这份包的交付边界

--- a/README.en.md
+++ b/README.en.md
@@ -47,8 +47,9 @@ In one sentence:
 ## What this project does
 Many markdown or Obsidian-style vaults eventually drift into a mix of task logs, navigation notes, and unstable process history. This kit separates that problem into two repeatable workflows:
 
-1. **Maintenance** — integrate durable conclusions into a vault
-2. **Audit** — inspect vault structure, metadata, navigation coverage, and noise regression
+1. **Ingest** — split long markdown sources or books into reusable knowledge-base pages
+2. **Maintenance** — integrate durable conclusions into a vault
+3. **Audit** — inspect vault structure, metadata, navigation coverage, and noise regression
 
 The kit keeps a fixed page-role model:
 - `project`
@@ -86,7 +87,7 @@ But leaves these pieces configurable through a vault profile:
 | Platform | Status | Notes |
 |---|---|---|
 | Codex / ChatGPT Codex-style skill directories | Recommended | Repository includes `SKILL.md`, `references/`, and `agents/openai.yaml` |
-| Claude-style skill directories | Works | Copy the three skill folders directly |
+| Claude-style skill directories | Works | Copy the four skill folders directly |
 | Other platforms supporting `SKILL.md` bundles | Maybe | Invocation and discovery may need adaptation |
 
 ## Repository layout
@@ -102,6 +103,7 @@ wiki-knowledgebase-share-kit/
     example-vault-profile-generic.md
   skills/
     knowledge-base-kit-guide/
+    knowledge-base-ingest/
     knowledge-base-maintenance/
     knowledge-base-audit/
 ```
@@ -110,7 +112,7 @@ wiki-knowledgebase-share-kit/
 1. Read `/START-HERE.md`
 2. Copy `templates/vault-profile-template.md` and fill it for your own vault
 3. Review `examples/example-vault-profile-generic.md`
-4. Install the three skill directories into your AI platform's `skills/` folder
+4. Install the four skill directories into your AI platform's `skills/` folder
 5. Start with `knowledge-base-kit-guide`
 
 ## Principles

--- a/README.md
+++ b/README.md
@@ -57,8 +57,9 @@
 
 这套 kit 把这些问题抽成两类能力：
 
-1. **Maintenance**：把任务结果或结论沉淀进知识库
-2. **Audit**：检查知识库结构、导航、元数据和噪音回流
+1. **Ingest**：把长 markdown / 书稿 / 教程按章节拆分并导入知识库
+2. **Maintenance**：把任务结果或结论沉淀进知识库
+3. **Audit**：检查知识库结构、导航、元数据和噪音回流
 
 同时保留固定页面角色模型：
 - `project`
@@ -98,7 +99,7 @@
 | 平台 | 状态 | 说明 |
 |---|---|---|
 | Codex / ChatGPT Codex 风格 skills 目录 | 推荐 | 仓库已包含 `SKILL.md`、`references/`、`agents/openai.yaml` |
-| Claude 风格 skills 目录 | 可用 | 直接复制三个 skill 目录即可 |
+| Claude 风格 skills 目录 | 可用 | 直接复制四个 skill 目录即可 |
 | 其他支持 `SKILL.md` 目录结构的平台 | 可能可用 | 需自行适配调用方式与 skill 发现机制 |
 
 如果你不确定平台兼容性，先看：
@@ -121,6 +122,7 @@ wiki-knowledgebase-share-kit/
     example-vault-profile-generic.md
   skills/
     knowledge-base-kit-guide/
+    knowledge-base-ingest/
     knowledge-base-maintenance/
     knowledge-base-audit/
 ```
@@ -141,9 +143,10 @@ wiki-knowledgebase-share-kit/
 
 ## 推荐安装方式
 
-把以下三个目录复制到你的 skills 目录：
+把以下四个目录复制到你的 skills 目录：
 
 - `skills/knowledge-base-kit-guide`
+- `skills/knowledge-base-ingest`
 - `skills/knowledge-base-maintenance`
 - `skills/knowledge-base-audit`
 
@@ -168,9 +171,10 @@ wiki-knowledgebase-share-kit/
 - 先用 `knowledge-base-kit-guide` 理解安装顺序、profile 配置和技能分工
 
 ### 日常使用
+- 要导入长文档 / 书籍 / 教程时：用 `knowledge-base-ingest`
 - 要沉淀任务结果时：用 `knowledge-base-maintenance`
 - 要做结构审计时：用 `knowledge-base-audit`
-- 大改之后：先 maintenance，再 audit
+- 大改之后：先 ingest / maintenance，再 audit
 
 ---
 

--- a/START-HERE.md
+++ b/START-HERE.md
@@ -7,22 +7,25 @@
 
 ## 你拿到的是什么
 
-这是一个可直接复用的 **wiki / markdown 知识库维护包**，里面有 3 个 skill：
+这是一个可直接复用的 **wiki / markdown 知识库维护包**，里面有 4 个 skill：
 
 1. `knowledge-base-kit-guide`
    - 负责安装说明、profile 配置说明、技能分流
-2. `knowledge-base-maintenance`
+2. `knowledge-base-ingest`
+   - 负责把长 markdown / 书稿 / 教程拆分、链接并导入知识库
+3. `knowledge-base-maintenance`
    - 负责把任务结果沉淀进知识库
-3. `knowledge-base-audit`
+4. `knowledge-base-audit`
    - 负责检查知识库结构、导航、元数据和噪音回流
 
 ---
 
 ## 最短上手步骤
 
-### 第 1 步：把 3 个 skill 复制到你的 skills 目录
-复制这 3 个目录：
+### 第 1 步：把 4 个 skill 复制到你的 skills 目录
+复制这 4 个目录：
 - `skills/knowledge-base-kit-guide`
+- `skills/knowledge-base-ingest`
 - `skills/knowledge-base-maintenance`
 - `skills/knowledge-base-audit`
 
@@ -54,6 +57,7 @@ I want to configure my vault profile and understand which skill to use first.
 ```
 
 ### 第 4 步：开始日常使用
+- 要导入长文档/书籍：用 `knowledge-base-ingest`
 - 要写入知识库：用 `knowledge-base-maintenance`
 - 要检查结构健康：用 `knowledge-base-audit`
 

--- a/docs/example-prompts.md
+++ b/docs/example-prompts.md
@@ -1,5 +1,12 @@
 # Example Prompts
 
+## 0. 导入一本 markdown 书到知识库
+
+```text
+Use $knowledge-base-ingest to import this markdown book into my knowledge base.
+Read my vault profile first, split the source into reusable chapter/topic pages, create navigation and related links, preserve source lineage, and sync the necessary entrypoints.
+```
+
 ## 1. 第一次安装后，不知道怎么开始
 
 ```text

--- a/docs/index.html
+++ b/docs/index.html
@@ -102,7 +102,7 @@
         <div class="eyebrow">Knowledge-base-first workflow kit</div>
         <h1>Keep your markdown vault useful, not noisy.</h1>
         <p class="lede">
-          A reusable open-source kit with 3 installable skills, profile-driven configuration,
+          A reusable open-source kit with 4 installable skills, profile-driven configuration,
           and a maintenance/audit split for markdown and wiki knowledge bases.
         </p>
         <div class="cta-row">
@@ -121,8 +121,8 @@
       <aside class="panel stat-card">
         <div>
           <div class="kicker">Core package</div>
-          <div class="metric">3</div>
-          <p class="stat-copy">Guide, maintenance, and audit skills designed to work together while staying reusable across vaults.</p>
+          <div class="metric">4</div>
+          <p class="stat-copy">Guide, ingest, maintenance, and audit skills designed to work together while staying reusable across vaults.</p>
         </div>
         <div>
           <div class="kicker">Method constraints</div>
@@ -174,6 +174,10 @@
         <p>Explains installation, profile setup, and which skill to use first when the user is new to the kit.</p>
       </article>
       <article class="panel card">
+        <h3>knowledge-base-ingest</h3>
+        <p>Splits long markdown sources or books into reusable pages, builds navigation links, and imports them into the knowledge base.</p>
+      </article>
+      <article class="panel card">
         <h3>knowledge-base-maintenance</h3>
         <p>Writes durable conclusions into the right page role, filters process noise, and syncs content plus navigation surfaces.</p>
       </article>
@@ -203,9 +207,9 @@
     <h2>How it flows</h2>
     <p class="sub">The workflow is intentionally simple: configure once, then run maintenance and audit as separate loops.</p>
     <div class="flow">
-      <article class="panel step"><small>01</small><strong>Install</strong><span>Copy the three skill folders into your AI platform’s <code>skills/</code> directory.</span></article>
+      <article class="panel step"><small>01</small><strong>Install</strong><span>Copy the four skill folders into your AI platform’s <code>skills/</code> directory.</span></article>
       <article class="panel step"><small>02</small><strong>Profile</strong><span>Fill the vault profile template with your vault root, root pages, areas, and metadata rules.</span></article>
-      <article class="panel step"><small>03</small><strong>Maintain</strong><span>Use maintenance to write durable conclusions and reusable troubleshooting knowledge.</span></article>
+      <article class="panel step"><small>03</small><strong>Ingest / Maintain</strong><span>Use ingest for long-form sources or maintenance for durable conclusions and reusable troubleshooting knowledge.</span></article>
       <article class="panel step"><small>04</small><strong>Audit</strong><span>Run audit after bigger changes or on a schedule to catch drift, dead links, and noise regression.</span></article>
     </div>
   </div>

--- a/docs/usage-sop.md
+++ b/docs/usage-sop.md
@@ -1,6 +1,6 @@
 # Usage SOP
 
-## 三个 skill 的职责分工
+## 四个 skill 的职责分工
 
 ### `knowledge-base-kit-guide`
 用于：
@@ -8,6 +8,13 @@
 - 教用户怎么填写 `vault profile`
 - 判断当前该先用 maintenance 还是 audit
 - 给第一次接触这套 kit 的人做分流说明
+
+### `knowledge-base-ingest`
+用于：
+- 把长 markdown 文档、书稿、教程或大章节导入知识库
+- 先按章节/主题拆分，再建立 parent-child / prev-next / related links
+- 把长文档重组为 overview + chapter + topic 页面群
+- 避免把整本书直接作为一个超长页面写回 wiki
 
 ### `knowledge-base-maintenance`
 用于：
@@ -28,25 +35,42 @@
 
 ## 标准工作流
 
-### 场景 A：任务完成后沉淀知识
+### 场景 A：导入长文档 / 书籍
+1. 先用 `knowledge-base-ingest`
+2. 如果导入规模较大，再用 `knowledge-base-audit` 做复检
+
+也就是：**先拆并写，再审**。
+
+### 场景 B：任务完成后沉淀知识
 1. 先用 `knowledge-base-maintenance`
 2. 如果改动较大，再用 `knowledge-base-audit` 做复检
 
 也就是：**先写，再审**。
 
-### 场景 B：怀疑知识库已经乱了
+### 场景 C：怀疑知识库已经乱了
 1. 先用 `knowledge-base-audit`
 2. 根据问题清单，再用 `knowledge-base-maintenance` 去修
 
 也就是：**先查，再写**。
 
-### 场景 C：周期巡检
+### 场景 D：周期巡检
 定期只跑 `knowledge-base-audit`，看有没有：
 - 入口丢失
 - 页面边界漂移
 - 根页堆流水
 - `ops` 页退化成日志
 - `log.md` 变任务回放
+
+---
+
+## Ingest 的默认回路
+
+1. 先读 vault profile 和 source markdown
+2. 先做 ingestion map
+3. 先拆分，再决定落页
+4. 建立 parent-child / prev-next / related links
+5. 同步 overview / root page / reader entry / milestone log
+6. 汇报导入结构和压缩策略
 
 ---
 

--- a/skills/knowledge-base-ingest/SKILL.md
+++ b/skills/knowledge-base-ingest/SKILL.md
@@ -1,0 +1,141 @@
+---
+name: knowledge-base-ingest
+description: This skill should be used when the user asks to import a long markdown document, handbook, book, tutorial, notes dump, or chapter collection into a markdown/wiki knowledge base. Use it when Codex needs to split long-form source material into reusable pages, create parent/child and sibling links, preserve source lineage, and sync the result into the user's knowledge base instead of leaving the source as one giant page. Trigger on requests like "import this markdown book", "拆分这本书到知识库", "把这份长文档拆开并建立链接", "按章节导入 wiki", or "把整本 markdown 维护进知识库".
+---
+
+# Knowledge Base Ingest
+
+把**长 markdown 文档 / 整本书 / 大型教程 / 章节合集**导入 markdown/wiki 知识库。
+
+它和 `knowledge-base-maintenance` 的区别是：
+- `knowledge-base-maintenance`：处理一次任务结果、聊天结论、排障经验的回写
+- `knowledge-base-ingest`：处理**长源材料**，先拆分，再重组，再链接，再写入知识库
+
+默认目标不是把整本书原样塞进 vault，而是把它整理成：
+- 可导航的 overview / chapter / topic 页面
+- 可复用的知识页与方法页
+- 有 parent/child / prev/next / related links 的结构化知识库
+
+## Required input
+
+执行前先读取：
+- `references/vault-profile-contract.md`
+- `references/ingestion-checklist.md`
+- `references/chunking-strategy.md`
+- `../../templates/vault-profile-template.md`
+
+默认需要这些输入：
+- source markdown 文件路径，或用户直接提供的大段 markdown
+- vault profile
+- source title / source type（book, handbook, notes, tutorial, spec）
+- 是否允许较多保留原文（默认否，默认以总结重组为主）
+
+如果缺少 profile，不要猜测 root pages 或页面目录。
+
+## Core rules
+
+- **先分块，再写入。** 不要把长文档整页导入知识库。
+- **先做 ingestion map，再动目标文件。** 先确定 part / chapter / section / topic 的落点。
+- **优先知识库口径，而不是原文镜像口径。**
+- **保留 source lineage。** 每个导入页面都应能看出来自哪本书、哪一章、哪一节。
+- **链接优先级高于排版复刻。**
+- **默认少引原文，多做结构化总结。** 除非用户明确要求归档型导入，或明确拥有相应内容权利。
+- **不要制造死链或孤立页。**
+- **每次实质导入至少同步：** 目标页群、对应 root page、reader entrypoint、milestone log。
+
+## Recommended workflow
+
+### 1. Read source and profile
+- 读取长文档或源书稿
+- 读取 vault profile
+- 判断 source 类型：book / handbook / spec / tutorial / notes dump
+- 识别目录结构：part / chapter / section / appendix / glossary
+
+### 2. Build the ingestion map first
+先生成一个 page map，而不是直接开始写：
+- source overview page
+- part pages（如需要）
+- chapter pages
+- topic pages / concept pages / runbook pages（按内容类型抽出）
+- 哪些内容不入库，只保留简短索引或摘要
+
+如果文档过长，先运行：
+- `python3 scripts/split_markdown.py <source.md> --out <dir>`
+
+### 3. Decide split granularity
+优先遵循：
+- H1/H2 对应大的章节单元
+- 过长章节再按更深一层标题拆分
+- 单页尽量保持在**一个可读、可维护的长度**，避免再次变成长页
+
+默认不要做：
+- 每个小标题都拆成碎片页
+- 把一本书只做成一个 overview 页
+- 把原目录照搬成一堆没有知识价值的壳页
+
+### 4. Classify by page role
+导入时仍遵循固定 page-role model：
+- `overview`：这本书 / 这份源材料的总览、目录、 ingestion rules
+- `knowledge`：概念、框架、模型、结论、定义、方法论
+- `ops`：步骤、操作法、排障法、执行边界、可复用 runbook
+- `project`：当 source 明显服务于某个长期专题主线时，作为稳定入口页
+- `task`：通常不作为书籍导入的主要落点，除非源文档本身就是协作任务结构
+
+### 5. Create the link model
+至少建立这些链接：
+- parent / child
+- prev / next
+- sibling / related
+- source overview backlink
+- root page / reader entrypoint entry
+
+如果某一页只是孤零零的摘录页，不应视为完成导入。
+
+### 6. Rewrite into knowledge-base form
+写入时：
+- 压缩重复叙述
+- 合并平行概念
+- 把长段论述改写成更利于检索的结构
+- 保留必要 source attribution（书名、章节、版本、作者）
+- 如需保留原文，只保留短引用和关键原句，避免大段照搬
+
+### 7. Sync navigation surfaces
+至少同步：
+- source overview page
+- 对应 root page
+- reader entrypoint
+- milestone log
+
+必要时再更新：
+- glossary
+- governance / maintainer overview
+- related topic hubs
+
+### 8. Validate before finishing
+检查：
+- 有没有单页过长
+- 有没有只拆分但没建立链接
+- 有没有 source lineage 丢失
+- 有没有把一本书直接导成原文镜像
+- 有没有 orphan pages / missing entrypoints
+- 页面角色是否合理
+
+## Output expectations
+
+汇报时至少说明：
+- source 被拆成了哪些页面组
+- page-role 是如何判定的
+- 建了哪些关键链接
+- 哪些原文被压缩 / 总结 / 改写
+- 是否同步了 root page / reader entrypoint / milestone log
+- 是否仍有待二次整理的大章节
+
+## Resources
+
+### scripts/
+- `scripts/split_markdown.py`：按标题层级做 deterministic split，输出 chunk 文件和 manifest
+
+### references/
+- `references/vault-profile-contract.md`：导入前需要哪些 profile 信息
+- `references/ingestion-checklist.md`：固定导入回路和验收清单
+- `references/chunking-strategy.md`：如何决定 chapter / section / topic 的拆分粒度

--- a/skills/knowledge-base-ingest/agents/openai.yaml
+++ b/skills/knowledge-base-ingest/agents/openai.yaml
@@ -1,0 +1,6 @@
+interface:
+  display_name: "Knowledge Base 导入"
+  short_description: "把整本书或超长Markdown拆分链接并维护进知识库页面群"
+  default_prompt: "Use $knowledge-base-ingest to import this long markdown document or book into my knowledge base: split it into reusable pages, create navigation links, and sync the necessary entrypoints."
+policy:
+  allow_implicit_invocation: true

--- a/skills/knowledge-base-ingest/references/chunking-strategy.md
+++ b/skills/knowledge-base-ingest/references/chunking-strategy.md
@@ -1,0 +1,73 @@
+# Chunking Strategy for Long Markdown Sources
+
+## Goal
+Split long-form source material into chunks that are:
+- readable
+- reusable
+- linkable
+- maintainable in a wiki knowledge base
+
+## Recommended split order
+
+### 1. Prefer natural source boundaries
+Use the source's own structure first:
+- part
+- chapter
+- section
+- appendix
+- glossary
+
+### 2. Split at the shallowest useful heading level
+Typical defaults:
+- book / handbook: start at H2 (chapter level)
+- technical spec: start at H2 or H3
+- notes dump: start where stable themes begin, not every timestamp
+- tutorial: start at lesson or step group level
+
+### 3. Re-split oversized chunks
+If a chunk is still too large:
+- split by the next heading level
+- or convert one chapter into an overview + subtopic pages
+
+## Heuristics
+
+### Good chunk
+- answers one stable question
+- has a clear parent topic
+- can be linked from overview and root pages
+- is small enough to read and maintain without scrolling through a book-length page
+
+### Bad chunk
+- mixes multiple chapters
+- is only a raw dump of copied prose
+- has no obvious inbound links
+- is too small to justify its own page
+
+## Good page families
+
+### Source overview page
+Contains:
+- source identity
+- author / edition / origin
+- what was imported
+- page map
+- navigation links
+
+### Chapter page
+Contains:
+- chapter summary
+- key concepts
+- links to subtopics
+- links to previous / next chapter pages
+
+### Topic page
+Contains:
+- normalized concept or method
+- source references
+- related links to neighboring ideas
+
+## Anti-patterns
+- one page per paragraph
+- one page for an entire book
+- pure TOC pages with no knowledge content
+- importing the source but forgetting to build navigation

--- a/skills/knowledge-base-ingest/references/ingestion-checklist.md
+++ b/skills/knowledge-base-ingest/references/ingestion-checklist.md
@@ -1,0 +1,50 @@
+# Long-Form Ingestion Checklist
+
+## Fixed ingest loop
+1. Read source markdown and vault profile
+2. Decide source type and target knowledge structure
+3. Build an ingestion map before editing files
+4. Split the source into manageable chunks
+5. Decide page role and area for each page group
+6. Rewrite into knowledge-base form
+7. Add navigation and cross-links
+8. Sync root page / reader entrypoint / milestone log
+9. Validate page length, coverage, and link integrity
+
+## Minimum output set
+Every substantial import should produce at least:
+- one source overview page
+- one or more chapter/topic pages
+- links between these pages
+- an entry from a root page or reader entrypoint
+- a milestone log update
+
+## Link model checklist
+Each imported page group should consider:
+- parent link
+- child list
+- prev / next navigation
+- related topic links
+- source attribution
+
+## Default compression rules
+Prefer:
+- summaries
+- rewritten outlines
+- concept extraction
+- normalized terminology
+- merged repeated explanations
+
+Avoid by default:
+- giant verbatim chapter copies
+- raw appendix dumps with no navigation
+- pages that only mirror the original table of contents
+- dozens of micro-pages with no retrieval value
+
+## Validation checklist
+- no page should remain a giant monolith if a better split is obvious
+- no imported page should be orphaned
+- source lineage should be visible
+- page role should match content
+- entrypoints should be updated
+- milestone log should capture the import event

--- a/skills/knowledge-base-ingest/references/vault-profile-contract.md
+++ b/skills/knowledge-base-ingest/references/vault-profile-contract.md
@@ -1,0 +1,28 @@
+# Vault Profile Contract
+
+## The ingest skill should not proceed without these facts
+- vault root path
+- markdown page directory
+- reader entrypoint file
+- milestone log file
+- maintainer entrypoint file
+- area list
+- root page map
+- canonical root-level markdown files
+- frontmatter contract
+
+## Why this matters
+Long-form ingestion creates many pages at once. Without a profile, the skill cannot safely decide:
+- where overview pages should live
+- which root page should own a chapter/topic page group
+- which files are allowed at the vault root
+- how imported pages should be tagged and typed
+
+## If the profile is missing
+Ask for the minimum missing configuration before editing files.
+Do not guess:
+- root page filenames
+- area names
+- page directory layout
+- metadata fields
+- log policy

--- a/skills/knowledge-base-ingest/scripts/split_markdown.py
+++ b/skills/knowledge-base-ingest/scripts/split_markdown.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List
+
+HEADING_RE = re.compile(r'^(#{1,6})\s+(.*\S)\s*$')
+NON_SLUG_RE = re.compile(r'[^a-z0-9]+')
+
+
+@dataclass
+class Heading:
+    line_index: int
+    level: int
+    title: str
+
+
+@dataclass
+class Chunk:
+    title: str
+    level: int
+    slug: str
+    lines: List[str]
+    start_line: int
+    end_line: int
+    word_count: int
+
+
+def slugify(text: str) -> str:
+    text = text.lower().strip()
+    text = NON_SLUG_RE.sub('-', text)
+    text = text.strip('-')
+    return text or 'section'
+
+
+def find_headings(lines: List[str]) -> List[Heading]:
+    headings: List[Heading] = []
+    for idx, line in enumerate(lines):
+        m = HEADING_RE.match(line)
+        if m:
+            headings.append(Heading(idx, len(m.group(1)), m.group(2).strip()))
+    return headings
+
+
+def choose_level(headings: List[Heading], requested: int) -> int:
+    levels = {h.level for h in headings}
+    if requested in levels:
+        return requested
+    for level in range(requested + 1, 7):
+        if level in levels:
+            return level
+    for level in range(requested - 1, 0, -1):
+        if level in levels:
+            return level
+    return 1
+
+
+def count_words(lines: List[str]) -> int:
+    return len(re.findall(r'\b\w+\b', ''.join(lines)))
+
+
+def split_range(lines: List[str], headings: List[Heading], level: int, start: int, end: int, max_words: int) -> List[Chunk]:
+    scoped = [h for h in headings if start <= h.line_index < end and h.level == level]
+    if not scoped:
+        title = f'part-{start + 1}'
+        chunk_lines = lines[start:end]
+        return [Chunk(title, level, slugify(title), chunk_lines, start + 1, end, count_words(chunk_lines))]
+
+    chunks: List[Chunk] = []
+    for i, heading in enumerate(scoped):
+        section_start = heading.line_index
+        if i + 1 < len(scoped):
+            section_end = scoped[i + 1].line_index
+        else:
+            next_shallower = [h.line_index for h in headings if h.line_index > heading.line_index and h.level < level and h.line_index < end]
+            section_end = min(next_shallower) if next_shallower else end
+        chunk_lines = lines[section_start:section_end]
+        word_count = count_words(chunk_lines)
+
+        deeper = [h for h in headings if section_start < h.line_index < section_end and h.level == level + 1]
+        if max_words and word_count > max_words and deeper and level < 6:
+            chunks.extend(split_range(lines, headings, level + 1, section_start, section_end, max_words))
+            continue
+
+        chunks.append(
+            Chunk(
+                title=heading.title,
+                level=heading.level,
+                slug=slugify(heading.title),
+                lines=chunk_lines,
+                start_line=section_start + 1,
+                end_line=section_end,
+                word_count=word_count,
+            )
+        )
+    return chunks
+
+
+def write_chunks(chunks: List[Chunk], output_dir: Path, prefix: str) -> None:
+    manifest = []
+    for idx, chunk in enumerate(chunks, start=1):
+        filename = f'{idx:03d}-{prefix}{chunk.slug}.md'
+        path = output_dir / filename
+        path.write_text(''.join(chunk.lines), encoding='utf-8')
+        manifest.append(
+            {
+                'index': idx,
+                'file': filename,
+                'title': chunk.title,
+                'level': chunk.level,
+                'start_line': chunk.start_line,
+                'end_line': chunk.end_line,
+                'word_count': chunk.word_count,
+            }
+        )
+    (output_dir / 'manifest.json').write_text(json.dumps(manifest, ensure_ascii=False, indent=2), encoding='utf-8')
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description='Split a long markdown file into heading-based chunks.')
+    parser.add_argument('source', help='Path to the source markdown file')
+    parser.add_argument('--out', required=True, help='Output directory for chunk files')
+    parser.add_argument('--level', type=int, default=2, help='Preferred heading level to split on (default: 2)')
+    parser.add_argument('--max-words', type=int, default=1800, help='Recursively split oversized chunks at the next heading level (default: 1800)')
+    parser.add_argument('--prefix', default='', help='Optional filename prefix, e.g. book-')
+    args = parser.parse_args()
+
+    source = Path(args.source)
+    output_dir = Path(args.out)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    lines = source.read_text(encoding='utf-8').splitlines(keepends=True)
+    headings = find_headings(lines)
+    if not headings:
+        raise SystemExit('No markdown headings found; add headings or split manually.')
+
+    level = choose_level(headings, args.level)
+    chunks = split_range(lines, headings, level, 0, len(lines), args.max_words)
+
+    preamble_start = headings[0].line_index
+    if preamble_start > 0:
+        preamble = lines[:preamble_start]
+        if ''.join(preamble).strip():
+            (output_dir / '000-preamble.md').write_text(''.join(preamble), encoding='utf-8')
+
+    write_chunks(chunks, output_dir, args.prefix)
+    print(json.dumps({'source': str(source), 'effective_level': level, 'chunks': len(chunks), 'output_dir': str(output_dir)}, ensure_ascii=False))
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/中文封面说明页.md
+++ b/中文封面说明页.md
@@ -22,12 +22,14 @@
 
 ## 这个包里有什么
 
-### 3 个 skills
+### 4 个 skills
 1. `knowledge-base-kit-guide`
    - 安装说明 / 配置说明 / 技能分流
-2. `knowledge-base-maintenance`
+2. `knowledge-base-ingest`
+   - 把长 markdown / 书稿 / 教程拆分、链接并导入知识库
+3. `knowledge-base-maintenance`
    - 把任务结果沉淀进知识库
-3. `knowledge-base-audit`
+4. `knowledge-base-audit`
    - 审计知识库结构、导航、元数据和噪音回流
 
 ### 1 个配置模板
@@ -53,7 +55,7 @@
 1. 看 `START-HERE.md`
 2. 复制 `templates/vault-profile-template.md`
 3. 填你的 vault 路径、areas、root pages、frontmatter 规则
-4. 把 3 个 skills 复制到你的 skills 目录
+4. 把 4 个 skills 复制到你的 skills 目录
 5. 第一次先用 `knowledge-base-kit-guide`
 
 ### 如果你想先了解方法论
@@ -111,6 +113,13 @@
 先读 vault profile，再过滤过程噪音，按页面角色归类，并同步目标页、root page、reader entry 和 milestone log。
 ```
 
+### 想导入一本 markdown 书或长文档时可以说
+
+```text
+用 $knowledge-base-ingest 把这本 markdown 书导入我的知识库。
+先读 vault profile，再按章节/主题拆分，建立导航和 related links，并同步 overview、reader entry 和 milestone log。
+```
+
 ### 想做结构体检时可以说
 
 ```text
@@ -126,7 +135,7 @@
 
 ```text
 这是一个可复用的 wiki/markdown 知识库维护包。
-先看《中文封面说明页.md》或 START-HERE.md，再复制 3 个 skills，填 vault-profile-template.md，然后先用 knowledge-base-kit-guide 上手。
+先看《中文封面说明页.md》或 START-HERE.md，再复制 4 个 skills，填 vault-profile-template.md，然后先用 knowledge-base-kit-guide 上手。
 ```
 
 ---


### PR DESCRIPTION
## What changed
- added a new `knowledge-base-ingest` skill for importing long markdown sources and books into the knowledge base
- added `split_markdown.py` for deterministic heading-based chunking with manifest output
- added ingest-specific references for profile requirements, chunking strategy, and ingestion validation
- updated README, START-HERE, cover pages, usage SOP, example prompts, delivery notes, and the landing page to reflect the new skill

## Why it changed
The existing kit handled maintenance and audit well, but it did not yet cover long-form ingestion. This adds a dedicated workflow for turning large markdown sources into reusable, linkable knowledge-base pages instead of one giant imported page.

## Validation
- `quick_validate.py skills/knowledge-base-ingest` passed
- local link check passed
- `split_markdown.py` tested on a sample markdown file and produced chunk files plus `manifest.json`
