### PR TITLE
Add working profile skill

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,28 @@
+# OS
 .DS_Store
 Thumbs.db
+
+# Python
+__pycache__/
+*.py[cod]
+*.egg-info/
+dist/
+build/
+.env
+*.key
+*.pem
+
+# IDE
+.vscode/
+.idea/
+*.swp
+
+# Archives
 *.zip
+
+# Generated outputs (from ingest scripts)
+related-links.json
+related-links.md
+glossary-candidates.json
+glossary-candidates.md
+manifest.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 ### Added
+- Added a new `knowledge-base-working-profile` skill for distilling stable collaboration profiles from ongoing interaction without storing sensitive personal data.
+- Added `templates/working-profile-page-template.md` plus optional working-profile settings in the vault profile template.
 - Added a new `knowledge-base-ingest` skill for splitting long markdown sources or books into reusable knowledge-base pages.
 - Added a test-driven ingest case study for long-form professional markdown sources at `examples/case-study-pathology-ingest-iteration.md`.
 - Expanded the ingest case study to frame `knowledge-base-ingest` as a lightweight harness / regression baseline for structure evolution.
@@ -14,8 +16,9 @@ All notable changes to this project will be documented in this file.
 - Developer list updated to `邹星宇` and `杨琦` in the main repository surfaces.
 
 ### Changed
+- Updated README, START-HERE, customization guide, usage SOP, example prompts, and landing page to include working-profile guidance and a 5-skill package view.
 - Improved Chinese and English README files with a 30-second overview, platform status, clearer audience fit guidance, and test-driven ingest case-study links.
-- Updated example prompts, usage SOP, and the GitHub Pages landing page to emphasize baseline import, lightweight harness framing, regression checks, and iterative knowledge-architecture refinement.
+- Updated example prompts, usage SOP, and the GitHub Pages landing page to emphasize baseline import, lightweight harness framing, regression checks, iterative knowledge-architecture refinement, and privacy-bounded working-profile distillation.
 
 ## [1.0.1] - 2026-04-16
 ### Added

--- a/COVER-CN.md
+++ b/COVER-CN.md
@@ -22,18 +22,21 @@
 
 ## 这个包里有什么
 
-### 4 个 skills
+### 5 个 skills
 1. `knowledge-base-kit-guide`
    - 安装说明 / 配置说明 / 技能分流
 2. `knowledge-base-ingest`
    - 把长 markdown / 书稿 / 教程拆分、链接并导入知识库
 3. `knowledge-base-maintenance`
    - 把任务结果沉淀进知识库
-4. `knowledge-base-audit`
+4. `knowledge-base-working-profile`
+   - 把持续沟通中的稳定偏好、决策习惯和协作边界沉淀成 working profile
+5. `knowledge-base-audit`
    - 审计知识库结构、导航、元数据和噪音回流
 
-### 1 个配置模板
+### 2 个模板
 - `templates/vault-profile-template.md`
+- `templates/working-profile-page-template.md`
 
 ### 1 套说明文档
 - `README.md`
@@ -55,7 +58,7 @@
 1. 看 `START-HERE.md`
 2. 复制 `templates/vault-profile-template.md`
 3. 填你的 vault 路径、areas、root pages、frontmatter 规则
-4. 把 4 个 skills 复制到你的 skills 目录
+4. 把 5 个 skills 复制到你的 skills 目录
 5. 第一次先用 `knowledge-base-kit-guide`
 
 ### 如果你想先了解方法论
@@ -120,6 +123,13 @@
 先读 vault profile，再按章节/主题拆分，建立导航和 related links，并同步 overview、reader entry 和 milestone log。
 ```
 
+### 想沉淀长期协作画像时可以说
+
+```text
+用 $knowledge-base-working-profile 从我们的持续沟通里更新我的 working profile。
+先读 vault profile，再只保留对未来协作有用的稳定信号，区分 confirmed / repeated / inferred，过滤敏感个人信息，并按 visibility 规则同步到目标画像页。
+```
+
 ### 想做结构体检时可以说
 
 ```text
@@ -135,7 +145,7 @@
 
 ```text
 这是一个可复用的 wiki/markdown 知识库维护包。
-先看《中文封面说明页.md》或 START-HERE.md，再复制 4 个 skills，填 vault-profile-template.md，然后先用 knowledge-base-kit-guide 上手。
+先看《中文封面说明页.md》或 START-HERE.md，再复制 5 个 skills，填 vault-profile-template.md，然后先用 knowledge-base-kit-guide 上手。
 ```
 
 ---

--- a/DELIVERY-NOTES.md
+++ b/DELIVERY-NOTES.md
@@ -13,7 +13,7 @@
 
 ```text
 这是一个可复用的 wiki/markdown 知识库维护包。
-先看 START-HERE.md，再复制 4 个 skills，填好 vault-profile-template.md，然后先用 knowledge-base-kit-guide 上手。
+先看 START-HERE.md，再复制 5 个 skills，填好 vault-profile-template.md，然后先用 knowledge-base-kit-guide 上手。
 ```
 
 ## 这份包的交付边界

--- a/README.en.md
+++ b/README.en.md
@@ -16,6 +16,7 @@ A reusable skill-and-docs kit for keeping markdown/wiki vaults structured, durab
 - [`examples/example-vault-profile-generic.md`](./examples/example-vault-profile-generic.md): generic profile example without personal paths
 - [`docs/customization-guide.md`](./docs/customization-guide.md): adapt the kit to your own vault
 - [`docs/example-prompts.md`](./docs/example-prompts.md): copy-ready prompts
+- [`templates/working-profile-page-template.md`](./templates/working-profile-page-template.md): working-profile page template
 - [`examples/case-study-pathology-ingest-iteration.md`](./examples/case-study-pathology-ingest-iteration.md): test-driven ingest case study
 - [`Releases`](https://github.com/zouxy111/wiki-knowledgebase-share-kit/releases): download published versions
 - [`GitHub Pages`](https://zouxy111.github.io/wiki-knowledgebase-share-kit/): browse the landing page
@@ -24,8 +25,8 @@ A reusable skill-and-docs kit for keeping markdown/wiki vaults structured, durab
 
 ## Developers
 
-- 邹星宇
-- 杨琦
+- Zou Xingyu (邹星宇)
+- Yang Qi (杨琦)
 
 ---
 
@@ -46,13 +47,14 @@ In one sentence:
 > This kit is not for recording more logs. It is for making a vault behave like a real knowledge base again.
 
 ## What this project does
-Many markdown or Obsidian-style vaults eventually drift into a mix of task logs, navigation notes, and unstable process history. This kit separates that problem into two repeatable workflows:
+Many markdown or Obsidian-style vaults eventually drift into a mix of task logs, navigation notes, and unstable process history. This kit separates that problem into four repeatable workflows:
 
 1. **Ingest** — split long markdown sources or books, generate TOC / glossary candidates / related-link suggestions, and import them as reusable knowledge-base pages
    - The first import is treated as a **testable baseline**, then refined through testing, regression checks, and version comparison
    - The ingest loop can also be treated as a lightweight harness for structure evolution
 2. **Maintenance** — integrate durable conclusions into a vault
-3. **Audit** — inspect vault structure, metadata, navigation coverage, and noise regression
+3. **Working Profile** — distill stable preferences, decision heuristics, and collaboration boundaries from ongoing interaction
+4. **Audit** — inspect vault structure, metadata, navigation coverage, and noise regression
 
 The kit keeps a fixed page-role model:
 - `project`
@@ -94,15 +96,16 @@ But leaves these pieces configurable through a vault profile:
 
 | Platform | Status | Notes |
 |---|---|---|
-| Codex / ChatGPT Codex-style skill directories | Recommended | Repository includes `SKILL.md`, `references/`, and `agents/openai.yaml` |
-| Claude-style skill directories | Works | Copy the four skill folders directly |
+| Codex / ChatGPT Codex-style skill directories | Recommended | Repository includes 5 skill bundles with `SKILL.md`, `references/`, and `agents/openai.yaml` |
+| Claude-style skill directories | Works | Copy the five skill folders directly |
 | Other platforms supporting `SKILL.md` bundles | Maybe | Invocation and discovery may need adaptation |
 
 ## Repository layout
 ```text
 wiki-knowledgebase-share-kit/
-  START-HERE.md
   COVER-CN.md
+  中文封面说明页.md
+  START-HERE.md
   README.md
   README.en.md
   docs/
@@ -113,16 +116,130 @@ wiki-knowledgebase-share-kit/
     knowledge-base-kit-guide/
     knowledge-base-ingest/
     knowledge-base-maintenance/
+    knowledge-base-working-profile/
     knowledge-base-audit/
 ```
+
+### `skills/`
+Can be directly copied to your local AI platform's `skills/` directory.
+
+### `docs/`
+Platform-independent documentation. You can maintain your knowledge base manually following these guides even without installing skills.
+
+### `templates/`
+Vault profile templates. Fill them out before using the skills, then point the skills to your profile.
+
+### `examples/`
+Contains both real case studies and **generic examples without personal paths**, making it easy for public repository readers to reference directly.
+
+---
+
+## Recommended installation method
+
+Copy the following five directories into your skills directory:
+
+- `skills/knowledge-base-kit-guide`
+- `skills/knowledge-base-ingest`
+- `skills/knowledge-base-maintenance`
+- `skills/knowledge-base-working-profile`
+- `skills/knowledge-base-audit`
+
+Common locations:
+- `~/.codex/skills`
+- `~/.claude/skills`
+
+After installation, prepare your own `vault profile` before calling any skill.
+
+---
+
+## Recommended usage order
+
+### First-time adaptation
+1. Read `docs/customization-guide.md`
+2. Copy `templates/vault-profile-template.md`
+3. Fill in your vault root, areas, root pages, and frontmatter rules
+4. Reference `examples/example-vault-profile-generic.md`
+5. Adjust checklists as needed
+
+### First-time setup
+- Start with `knowledge-base-kit-guide` to understand installation sequence, profile configuration, and skill responsibilities
+
+### Daily usage
+- To import long documents / books / tutorials: use `knowledge-base-ingest` (supports splitting, TOC, glossary candidates, related links suggestions, and lightweight harness-style structure iteration)
+- To capture task results: use `knowledge-base-maintenance`
+- To capture long-term collaboration profiles: use `knowledge-base-working-profile`
+- To perform structural audits: use `knowledge-base-audit`
+- After major changes: run ingest / maintenance first, then audit
+
+---
+
+## Fixed rules of this method
+
+The following items are fixed by default and should not be changed lightly:
+- Knowledge-base-first, do not collect one-off process noise
+- Page-role model: `project / knowledge / ops / task / overview`
+- Root pages are for navigation and stable overview only
+- `ops` pages default to "symptom / root cause / fix / boundary"
+- `log.md` records milestones only, not task playback
+- Each substantial maintenance must sync at least: target page, root page, `index.md`, `log.md`
+
+---
+
+## Customizable parts
+
+The following items should be defined by each user in their own `vault profile`:
+- Vault path
+- Pages directory
+- Reader entrypoint
+- Log file
+- Maintainer entrypoint
+- Area list
+- Root pages
+- Naming conventions
+- Frontmatter rules
+- Canonical markdown files allowed at vault root
+
+---
+
+## Recommended reading order
+
+Shortest path:
+- `COVER-CN.md`
+- `中文封面说明页.md`
+- `START-HERE.md`
+- `docs/customization-guide.md`
+- `templates/vault-profile-template.md`
+- `templates/working-profile-page-template.md`
+- `docs/usage-sop.md`
+
+If you want to see a complete real-world example, also read:
+- `examples/example-vault-profile-generic.md`
+- `examples/example-vault-profile.md`
+- `examples/case-study-current-vault.md`
+- `examples/case-study-pathology-ingest-iteration.md`
+
+---
+
+## Open-source repository supplement files
+
+To facilitate publishing to GitHub, this repository additionally provides:
+- `LICENSE`
+- `CONTRIBUTING.md`
+- `CHANGELOG.md`
+- `README.en.md`
+- `.gitignore`
+- `.github/workflows/validate.yml`
+
+If you are open-sourcing your own fork, keeping these files is sufficient.
 
 ## Quick start
 1. Read `/START-HERE.md`
 2. Copy `templates/vault-profile-template.md` and fill it for your own vault
 3. Review `examples/example-vault-profile-generic.md`
-4. Install the four skill directories into your AI platform's `skills/` folder
+4. Install the five skill directories into your AI platform's `skills/` folder
 5. Start with `knowledge-base-kit-guide`
-6. Review `examples/case-study-pathology-ingest-iteration.md` for a test-driven ingest example
+6. Use `knowledge-base-working-profile` when you want a durable collaboration profile instead of a one-off task summary
+7. Review `examples/case-study-pathology-ingest-iteration.md` for a test-driven ingest example
 
 ## Principles
 - knowledge-base-first, not process-log-first
@@ -138,7 +255,7 @@ wiki-knowledgebase-share-kit/
 - `.github/workflows/validate.yml` — basic repo validation
 
 ## Language
-The main docs are currently Chinese-first, with English prompts and this English summary for broader reuse.
+The main docs are currently Chinese-first, with English prompts and this English README for broader reuse.
 
 ## License
 Released under the MIT License. See `/LICENSE`.

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@
 - [`examples/example-vault-profile-generic.md`](./examples/example-vault-profile-generic.md)：不带个人路径的通用 profile 示例
 - [`docs/customization-guide.md`](./docs/customization-guide.md)：如何改造成自己的知识库体系
 - [`docs/example-prompts.md`](./docs/example-prompts.md)：可直接复制的提示词
+- [`templates/working-profile-page-template.md`](./templates/working-profile-page-template.md)：working profile 页面模板
 - [`examples/case-study-pathology-ingest-iteration.md`](./examples/case-study-pathology-ingest-iteration.md)：测试驱动的长文档导入案例
 - [`Releases`](https://github.com/zouxy111/wiki-knowledgebase-share-kit/releases)：下载发布版本
 - [`GitHub Pages`](https://zouxy111.github.io/wiki-knowledgebase-share-kit/)：浏览开源落地页
@@ -56,13 +57,14 @@
 - `index.md`、导航入口和里程碑日志不同步
 - 审计时不知道该检查结构、边界还是噪音回流
 
-这套 kit 把这些问题抽成两类能力：
+这套 kit 把这些问题抽成四类能力：
 
 1. **Ingest**：把长 markdown / 书稿 / 教程按章节拆分，并生成目录、术语候选和 related links 建议后导入知识库
    - 第一版导入只作为**可测试基线**，后续应根据测试结果继续优化拆分粒度、页面角色和链接架构
    - 整个 ingest 回路可以当作一个轻量 harness / 回归底座来用
 2. **Maintenance**：把任务结果或结论沉淀进知识库
-3. **Audit**：检查知识库结构、导航、元数据和噪音回流
+3. **Working Profile**：把持续沟通中反复出现的偏好、决策习惯和协作边界沉淀成 working profile
+4. **Audit**：检查知识库结构、导航、元数据和噪音回流
 
 同时保留固定页面角色模型：
 - `project`
@@ -85,15 +87,36 @@
 
 ### 适合
 - 已经在维护 Obsidian / markdown / wiki vault 的个人或团队
-- 想把“任务过程”和“长期知识”拆开的使用者
+- 想把"任务过程"和"长期知识"拆开的使用者
 - 接受固定页面角色模型：`project / knowledge / ops / task / overview`
-- 希望把“写入维护”和“结构审计”拆成两条明确工作流的人
+- 希望把"写入维护"和"结构审计"拆成两条明确工作流的人
+- 想把这份包直接分享给其他维护者的人（见下方"交付边界"）
 
 ### 不太适合
 - 完全不想配置 profile 的人
 - 希望 vault 继续以流水日志为主的人
 - 不接受固定页面角色模型的人
 - 只想记录原始过程，不在意知识沉淀和导航治理的人
+
+## 交付边界
+
+### 这份包已包含
+- 可安装 skill（5 个）
+- 安装与配置说明
+- vault profile 模板
+- 示例 profile
+- 使用口令示例
+
+### 这份包不包含
+- 自动生成 profile 的脚本
+- 针对某个平台的专用 installer
+- 针对某个业务领域的 area/root page 预设
+
+### 分享时的最短指引
+```text
+这是一个可复用的 wiki/markdown 知识库维护包。
+先看 START-HERE.md，再复制 5 个 skills，填好 vault-profile-template.md，然后先用 knowledge-base-kit-guide 上手。
+```
 
 ## 使用案例
 
@@ -106,8 +129,8 @@
 
 | 平台 | 状态 | 说明 |
 |---|---|---|
-| Codex / ChatGPT Codex 风格 skills 目录 | 推荐 | 仓库已包含 `SKILL.md`、`references/`、`agents/openai.yaml` |
-| Claude 风格 skills 目录 | 可用 | 直接复制四个 skill 目录即可 |
+| Codex / ChatGPT Codex 风格 skills 目录 | 推荐 | 仓库已包含 5 个 skill 的 `SKILL.md`、`references/`、`agents/openai.yaml` |
+| Claude 风格 skills 目录 | 可用 | 直接复制五个 skill 目录即可 |
 | 其他支持 `SKILL.md` 目录结构的平台 | 可能可用 | 需自行适配调用方式与 skill 发现机制 |
 
 如果你不确定平台兼容性，先看：
@@ -132,6 +155,7 @@ wiki-knowledgebase-share-kit/
     knowledge-base-kit-guide/
     knowledge-base-ingest/
     knowledge-base-maintenance/
+    knowledge-base-working-profile/
     knowledge-base-audit/
 ```
 
@@ -151,11 +175,12 @@ wiki-knowledgebase-share-kit/
 
 ## 推荐安装方式
 
-把以下四个目录复制到你的 skills 目录：
+把以下五个目录复制到你的 skills 目录：
 
 - `skills/knowledge-base-kit-guide`
 - `skills/knowledge-base-ingest`
 - `skills/knowledge-base-maintenance`
+- `skills/knowledge-base-working-profile`
 - `skills/knowledge-base-audit`
 
 常见位置示例：
@@ -181,6 +206,7 @@ wiki-knowledgebase-share-kit/
 ### 日常使用
 - 要导入长文档 / 书籍 / 教程时：用 `knowledge-base-ingest`（支持拆分、TOC、术语候选、related links 建议，以及轻量 harness 风格的结构迭代）
 - 要沉淀任务结果时：用 `knowledge-base-maintenance`
+- 要沉淀长期协作画像时：用 `knowledge-base-working-profile`
 - 要做结构审计时：用 `knowledge-base-audit`
 - 大改之后：先 ingest / maintenance，再 audit
 
@@ -222,6 +248,7 @@ wiki-knowledgebase-share-kit/
 - `START-HERE.md`
 - `docs/customization-guide.md`
 - `templates/vault-profile-template.md`
+- `templates/working-profile-page-template.md`
 - `docs/usage-sop.md`
 
 如果想看一个完整落地示例，再读：

--- a/START-HERE.md
+++ b/START-HERE.md
@@ -7,7 +7,7 @@
 
 ## 你拿到的是什么
 
-这是一个可直接复用的 **wiki / markdown 知识库维护包**，里面有 4 个 skill：
+这是一个可直接复用的 **wiki / markdown 知识库维护包**，里面有 5 个 skill：
 
 1. `knowledge-base-kit-guide`
    - 负责安装说明、profile 配置说明、技能分流
@@ -15,18 +15,21 @@
    - 负责把长 markdown / 书稿 / 教程拆分、链接并导入知识库
 3. `knowledge-base-maintenance`
    - 负责把任务结果沉淀进知识库
-4. `knowledge-base-audit`
+4. `knowledge-base-working-profile`
+   - 负责把持续沟通中的稳定偏好、决策习惯和协作边界沉淀成 working profile
+5. `knowledge-base-audit`
    - 负责检查知识库结构、导航、元数据和噪音回流
 
 ---
 
 ## 最短上手步骤
 
-### 第 1 步：把 4 个 skill 复制到你的 skills 目录
-复制这 4 个目录：
+### 第 1 步：把 5 个 skill 复制到你的 skills 目录
+复制这 5 个目录：
 - `skills/knowledge-base-kit-guide`
 - `skills/knowledge-base-ingest`
 - `skills/knowledge-base-maintenance`
+- `skills/knowledge-base-working-profile`
 - `skills/knowledge-base-audit`
 
 常见目标目录：
@@ -59,6 +62,7 @@ I want to configure my vault profile and understand which skill to use first.
 ### 第 4 步：开始日常使用
 - 要导入长文档/书籍：用 `knowledge-base-ingest`
 - 要写入知识库：用 `knowledge-base-maintenance`
+- 要沉淀 working profile：用 `knowledge-base-working-profile`
 - 要检查结构健康：用 `knowledge-base-audit`
 
 ---
@@ -122,3 +126,9 @@ I want to configure my vault profile and understand which skill to use first.
 - `.gitignore`
 
 也就是说，它不只是“可转发包”，也可以直接作为 GitHub 开源仓库初始化。
+
+### Working profile 沉淀
+```text
+用 $knowledge-base-working-profile 从我们的持续沟通里更新我的 working profile。
+先读取 vault profile，再只保留对未来协作有用的稳定信号，区分 confirmed / repeated / inferred，过滤敏感个人信息，并按 visibility 规则同步到目标画像页。
+```

--- a/docs/customization-guide.md
+++ b/docs/customization-guide.md
@@ -101,6 +101,16 @@ root page 是你的知识库主线入口。
 
 ---
 
+## 第 4.5 步：如果你要沉淀 working profile
+
+如果你准备使用 `knowledge-base-working-profile`，建议在 profile 中额外写清：
+- working profile page
+- 该页面是否 `maintainer-only` 还是 `reader-visible`
+- inferred 项采用多严格的确认阈值
+- 哪些内容类型永远不写入长期画像
+
+这一步的作用不是“多收集个人信息”，而是防止长期画像写错地方、写错可见范围、或写进不该保存的内容。
+
 ## 第 5 步：尽量不要改的核心原则
 
 如果你希望这套方法真的有效，尽量不要改掉：

--- a/docs/example-prompts.md
+++ b/docs/example-prompts.md
@@ -25,37 +25,51 @@ Use $knowledge-base-maintenance to integrate this task into my markdown knowledg
 Read my vault profile first. Keep only durable conclusions or reusable troubleshooting knowledge, choose the right page role, and sync the target page, relevant root page, reader entrypoint, and milestone log.
 ```
 
-## 3. 我怀疑 wiki 结构已经乱了
+## 3. 从持续沟通中更新 working profile
+
+```text
+Use $knowledge-base-working-profile to update my working profile from our recent interactions.
+Read my vault profile first, keep only collaboration-relevant stable signals, separate confirmed / repeated / inferred items, filter sensitive personal data, and sync the target profile page according to its visibility rules.
+```
+
+## 4. 我怀疑 wiki 结构已经乱了
 
 ```text
 Use $knowledge-base-audit to inspect my knowledge base.
 Read the vault profile first, then report dead links, orphan pages, missing entrypoints, metadata issues, page-boundary drift, noise regression, and stray markdown files at the vault root.
 ```
 
-## 4. 先审计，再修
+## 5. 先审计，再修
 
 ```text
 Use $knowledge-base-audit first to inspect my vault and list findings by priority.
 Then use $knowledge-base-maintenance to fix the high-priority issues while preserving the page-role model.
 ```
 
-## 5. 中文首次上手
+## 6. 中文首次上手
 
 ```text
 用 $knowledge-base-kit-guide 帮我开始用这套知识库维护包。
 我还没有配 vault profile，请先告诉我最少要补哪些信息，再告诉我下一步应该调用哪个 skill。
 ```
 
-## 6. 中文写入知识库
+## 7. 中文写入知识库
 
 ```text
 用 $knowledge-base-maintenance 把这次结果沉淀进我的知识库。
 先读 vault profile，再过滤过程噪音，按页面角色归类，并同步目标页、root page、reader entry 和 milestone log。
 ```
 
-## 7. 中文结构体检
+## 8. 中文结构体检
 
 ```text
 用 $knowledge-base-audit 审计我的知识库。
 先读 vault profile，再检查死链、孤立页、metadata、页面边界漂移、噪音回流，以及根目录 stray markdown 文件。
+```
+
+## 9. 中文沉淀 working profile
+
+```text
+用 $knowledge-base-working-profile 从我们的持续沟通里更新我的 working profile。
+先读 vault profile，再只保留对未来协作有用的稳定信号，区分 confirmed / repeated / inferred，过滤敏感个人信息，并按 visibility 规则同步到目标画像页。
 ```

--- a/docs/index.html
+++ b/docs/index.html
@@ -64,7 +64,7 @@
     .card { padding: 24px; }
     .card h3 { margin: 0 0 10px; font-size: 22px; }
     .card p { margin: 0; color: var(--muted); line-height: 1.75; }
-    .flow { display:grid; grid-template-columns: repeat(4, 1fr); gap: 14px; }
+    .flow { display:grid; grid-template-columns: repeat(5, 1fr); gap: 14px; }
     .step { padding: 20px; position:relative; }
     .step small { color: var(--accent); letter-spacing: .12em; text-transform: uppercase; }
     .step strong { display:block; margin: 10px 0 8px; font-size: 20px; }
@@ -102,8 +102,8 @@
         <div class="eyebrow">Knowledge-base-first workflow kit</div>
         <h1>Keep your markdown vault useful, not noisy.</h1>
         <p class="lede">
-          A reusable open-source kit with 4 installable skills, profile-driven configuration,
-          and an ingest / maintenance / audit split for markdown and wiki knowledge bases. The ingest loop is test-driven and can be used like a lightweight harness: start with a baseline, then refine structure through regression and comparison.
+          A reusable open-source kit with 5 installable skills, profile-driven configuration,
+          and an ingest / maintenance / working-profile / audit split for markdown and wiki knowledge bases. The kit also supports durable collaboration profiles without turning them into private dossiers.
         </p>
         <div class="cta-row">
           <a class="btn primary" href="https://github.com/zouxy111/wiki-knowledgebase-share-kit/releases/latest">Browse latest release</a>
@@ -121,8 +121,8 @@
       <aside class="panel stat-card">
         <div>
           <div class="kicker">Core package</div>
-          <div class="metric">4</div>
-          <p class="stat-copy">Guide, ingest, maintenance, and audit skills designed to work together while staying reusable across vaults.</p>
+          <div class="metric">5</div>
+          <p class="stat-copy">Guide, ingest, maintenance, working-profile, and audit skills designed to work together while staying reusable across vaults.</p>
         </div>
         <div>
           <div class="kicker">Method constraints</div>
@@ -182,6 +182,10 @@
         <p>Writes durable conclusions into the right page role, filters process noise, and syncs content plus navigation surfaces.</p>
       </article>
       <article class="panel card">
+        <h3>knowledge-base-working-profile</h3>
+        <p>Distills stable collaboration-relevant preferences, heuristics, and boundaries from ongoing interaction while filtering sensitive personal data.</p>
+      </article>
+      <article class="panel card">
         <h3>knowledge-base-audit</h3>
         <p>Checks metadata, dead links, orphan pages, boundary drift, navigation coverage, and noise regression.</p>
       </article>
@@ -190,7 +194,7 @@
 
   <div class="shell section">
     <h2>Who this is for</h2>
-    <p class="sub">This repository works best when the user accepts a small amount of structure in exchange for a much cleaner long-term vault.</p>
+    <p class="sub">This repository works best when the user accepts a small amount of structure in exchange for a much cleaner long-term vault and more stable collaboration memory.</p>
     <div class="grid-2">
       <article class="panel card">
         <h3>Good fit</h3>
@@ -207,10 +211,11 @@
     <h2>How it flows</h2>
     <p class="sub">The workflow is intentionally simple: configure once, then run maintenance and audit as separate loops.</p>
     <div class="flow">
-      <article class="panel step"><small>01</small><strong>Install</strong><span>Copy the four skill folders into your AI platform’s <code>skills/</code> directory.</span></article>
+      <article class="panel step"><small>01</small><strong>Install</strong><span>Copy the five skill folders into your AI platform’s <code>skills/</code> directory.</span></article>
       <article class="panel step"><small>02</small><strong>Profile</strong><span>Fill the vault profile template with your vault root, root pages, areas, and metadata rules.</span></article>
-      <article class="panel step"><small>03</small><strong>Ingest / Maintain</strong><span>Use ingest for long-form sources as a testable baseline, then run it like a lightweight harness: compare versions, refine split strategy, adjust page roles, and improve link architecture before locking in durable structure.</span></article>
-      <article class="panel step"><small>04</small><strong>Audit</strong><span>Run audit after bigger changes or on a schedule to catch drift, dead links, and noise regression.</span></article>
+      <article class="panel step"><small>03</small><strong>Ingest / Maintain</strong><span>Use ingest for long-form sources and maintenance for durable page updates without process noise.</span></article>
+      <article class="panel step"><small>04</small><strong>Working Profile</strong><span>Use working-profile when repeated collaboration signals should become a durable, privacy-bounded profile page.</span></article>
+      <article class="panel step"><small>05</small><strong>Audit</strong><span>Run audit after bigger changes or on a schedule to catch drift, dead links, and noise regression.</span></article>
     </div>
   </div>
 

--- a/docs/usage-sop.md
+++ b/docs/usage-sop.md
@@ -1,12 +1,12 @@
 # Usage SOP
 
-## 四个 skill 的职责分工
+## 五个 skill 的职责分工
 
 ### `knowledge-base-kit-guide`
 用于：
 - 教用户怎么安装这套分享包
 - 教用户怎么填写 `vault profile`
-- 判断当前该先用 maintenance 还是 audit
+- 判断当前该先用 ingest / maintenance / working-profile / audit 中的哪一个
 - 给第一次接触这套 kit 的人做分流说明
 
 ### `knowledge-base-ingest`
@@ -24,6 +24,13 @@
 - 把聊天结论写进合适页面
 - 收敛根页、知识页、运维页的写法边界
 - 把噪音挡在知识库外面
+
+### `knowledge-base-working-profile`
+用于：
+- 从持续沟通中提炼稳定的协作画像
+- 沉淀偏好、决策习惯、协作边界和反模式
+- 区分 confirmed / repeated / inferred，而不是把一次表达写死
+- 过滤敏感个人信息，避免把 working profile 做成隐私档案
 
 ### `knowledge-base-audit`
 用于：
@@ -63,6 +70,13 @@
 - 根页堆流水
 - `ops` 页退化成日志
 - `log.md` 变任务回放
+
+### 场景 E：持续协作时沉淀 working profile
+1. 先用 `knowledge-base-working-profile` 提炼本轮稳定信号
+2. 把一次性情绪、敏感细节和弱推断挡在长期画像外
+3. 只在需要公开可见时再同步 reader-facing 入口
+
+也就是：**先提炼，再分级，再决定可见范围**。
 
 ---
 
@@ -138,6 +152,14 @@
 - 是否同步了入口和日志
 - 哪些内容被判为噪音
 
+### working-profile
+至少说明：
+- 更新了哪些画像条目
+- 哪些属于 confirmed / repeated / inferred
+- 哪些内容因敏感或证据不足被过滤
+- 是否记录了 change note
+- 是否同步了对应入口页
+
 ### audit
 至少说明：
 - audit summary
@@ -159,3 +181,29 @@
 - 入口页与来源链的回归检查
 
 因此 `knowledge-base-ingest` 更像一个“测试驱动的结构整理回路”或“轻量 harness / 回归底座”，而不是一次性导入脚本。
+
+---
+
+## Working Profile 的默认回路
+
+1. 先读 vault profile 和当前 working profile 页面
+2. 收集本轮可作为证据的互动信号
+3. 先跑敏感信息过滤
+4. 抽取 stable facts / preferences / heuristics / boundaries / anti-patterns / provisional signals
+5. 标注 confirmed / repeated / inferred
+6. 更新 working profile 页面并补 change notes
+7. 按 visibility 规则决定是否同步 maintainer / reader 入口
+8. 检查是否误把一次性表达写成长期标签
+
+---
+
+## 什么时候不该用 working profile
+
+如果内容只是：
+- 一次性情绪
+- 与未来协作无关的私人细节
+- 高敏感个人信息
+- 未经确认的强推断
+- 对第三方的私人评价
+
+默认不应写进 working profile。

--- a/examples/example-vault-profile-generic.md
+++ b/examples/example-vault-profile-generic.md
@@ -126,3 +126,16 @@ updated: "2026-04-16"
 2. 导航问题
 3. 治理漂移
 4. 噪音回流
+
+---
+
+## 11. Working profile settings
+
+- Working profile page: `/path/to/your-vault/pages/workspace-working-profile.md`
+- Working profile visibility: `maintainer-only`
+- Confirmation threshold for inferred items: `medium`
+- Never-store categories:
+  - secrets / tokens / credentials
+  - precise home address or highly sensitive contact data
+  - third-party private data
+  - medical or legal sensitive details unless explicitly needed

--- a/skills/knowledge-base-kit-guide/SKILL.md
+++ b/skills/knowledge-base-kit-guide/SKILL.md
@@ -1,16 +1,18 @@
 ---
 name: knowledge-base-kit-guide
-description: This skill should be used when the user asks to "how do I use this wiki skill kit", "set up a markdown knowledge base workflow", "install the knowledge base skills", "which skill should I use first", "怎么用这套 skills", "怎么开始配置这套知识库维护包", "先用 maintenance 还是 audit", or "怎么填写 vault profile". It explains how to install, configure, and start using the knowledge-base share kit before day-to-day maintenance or audit work begins.
+description: This skill should be used when the user asks to "how do I use this wiki skill kit", "set up a markdown knowledge base workflow", "install the knowledge base skills", "which skill should I use first", "怎么用这套 skills", "怎么开始配置这套知识库维护包", "先用 ingest、maintenance 还是 audit", or "怎么填写 vault profile". It explains how to install, configure, and start using the knowledge-base share kit before day-to-day ingest, maintenance, working-profile, or audit work begins.
 ---
 
 # Knowledge Base Kit Guide
 
-这个 skill 不直接维护知识库，也不直接做审计。
+这个 skill 不直接导入长文档，不直接维护知识库，也不直接做审计。
 
 它的职责是：
 - 教用户如何安装这套 share kit
 - 教用户如何填写 `vault profile`
+- 教用户什么时候该用 `knowledge-base-ingest`
 - 教用户什么时候该用 `knowledge-base-maintenance`
+- 教用户什么时候该用 `knowledge-base-working-profile`
 - 教用户什么时候该用 `knowledge-base-audit`
 - 帮用户判断当前卡在哪个配置步骤
 
@@ -18,7 +20,7 @@ description: This skill should be used when the user asks to "how do I use this 
 - 用户第一次拿到这套 share kit，不知道从哪开始
 - 用户问“怎么安装这些 skills”
 - 用户问“怎么填写 vault profile”
-- 用户问“先用 maintenance 还是 audit”
+- 用户问“先用 ingest、maintenance 还是 audit”
 - 用户问“为什么这套模板还不能直接跑”
 
 ## What this skill should do
@@ -35,8 +37,8 @@ description: This skill should be used when the user asks to "how do I use this 
 1. 读 `README.md`
 2. 读 `docs/customization-guide.md`
 3. 复制并填写 `templates/vault-profile-template.md`
-4. 再安装 `knowledge-base-maintenance` 和 `knowledge-base-audit`
-5. 最后进入日常 maintenance / audit 工作流
+4. 再安装 `knowledge-base-kit-guide`、`knowledge-base-ingest`、`knowledge-base-maintenance`、`knowledge-base-working-profile` 和 `knowledge-base-audit`
+5. 最后进入日常 ingest / maintenance / working-profile / audit 工作流
 
 ### 3. Explain the fixed model vs customizable parts
 明确告诉用户：
@@ -44,7 +46,9 @@ description: This skill should be used when the user asks to "how do I use this 
 - 可自定义的是 vault 路径、area、root pages、命名规则、frontmatter 规则
 
 ### 4. Explain skill responsibilities
+- `knowledge-base-ingest`：把长文档/书稿拆分、链接并导入知识库，再通过测试与回归继续优化结构
 - `knowledge-base-maintenance`：把任务结果沉淀进知识库
+- `knowledge-base-working-profile`：把长期协作画像沉淀成 working profile
 - `knowledge-base-audit`：检查结构、导航、元数据和噪音回流
 - 本 skill：负责安装、上手、配置和分流说明
 

--- a/skills/knowledge-base-kit-guide/references/profile-setup-checklist.md
+++ b/skills/knowledge-base-kit-guide/references/profile-setup-checklist.md
@@ -18,6 +18,8 @@
 - 是否启用 knowledge-base-first mode
 - 是否启用 milestone-only log
 - 是否启用 `ops` 四段式写法
+- working profile page（如果你要沉淀长期协作画像）
+- working profile visibility 与 never-store categories
 
 ## 常见卡点
 

--- a/skills/knowledge-base-kit-guide/references/quickstart.md
+++ b/skills/knowledge-base-kit-guide/references/quickstart.md
@@ -7,11 +7,16 @@
 3. 复制 `templates/vault-profile-template.md`
 4. 填好你自己的 vault 路径、areas、root pages、frontmatter 规则
 5. 安装：
+   - `skills/knowledge-base-kit-guide`
+   - `skills/knowledge-base-ingest`
    - `skills/knowledge-base-maintenance`
+   - `skills/knowledge-base-working-profile`
    - `skills/knowledge-base-audit`
 6. 第一次落地时：
-   - 先用 maintenance 沉淀一个小结果
-   - 再用 audit 看结构是否健康
+   - 如有长文档/书籍导入需求，先用 ingest 建一个可测试基线
+   - 再用 maintenance 沉淀一个小结果
+   - 如有长期协作需要，再用 working-profile 建一个轻量画像页
+   - 最后用 audit 看结构是否健康
 
 ## 如果用户只想先看懂
 推荐顺序：

--- a/skills/knowledge-base-working-profile/SKILL.md
+++ b/skills/knowledge-base-working-profile/SKILL.md
@@ -1,0 +1,146 @@
+---
+name: knowledge-base-working-profile
+description: This skill should be used when the user asks to remember or update how they work, distill collaboration preferences from ongoing conversations, maintain a working profile in a markdown/wiki knowledge base, 沉淀协作画像, 更新我的工作偏好, 记录我的决策习惯, or 从沟通过程中整理长期画像. It extracts stable collaboration-relevant signals such as preferences, decision heuristics, boundaries, and anti-patterns, keeps confirmed and inferred items separate, and refuses to store secrets or overly sensitive personal data.
+---
+
+# Knowledge Base Working Profile
+
+把持续沟通中出现的**稳定协作信息**沉淀进 markdown/wiki 知识库。
+
+它处理的不是“原始个人资料”，而是未来协作真正会反复用到的东西，例如：
+- 稳定事实（仅限工作相关）
+- 偏好
+- 决策习惯
+- 协作边界
+- 反模式
+- 仍待确认的画像信号
+
+它和 `knowledge-base-maintenance` 的区别是：
+- `knowledge-base-maintenance`：沉淀某次任务/聊天/排障的结果
+- `knowledge-base-working-profile`：沉淀**这个人长期怎么合作、怎么判断、偏好什么、不喜欢什么**
+
+默认目标不是“做人格克隆”，也不是“存个人隐私档案”，而是形成一个**可持续更新的 working profile**，减少反复解释与协作摩擦。
+
+## Required input
+
+执行前先读取：
+- `references/working-profile-schema.md`
+- `references/evidence-thresholds.md`
+- `references/sensitivity-boundaries.md`
+- `../../templates/vault-profile-template.md`
+- `../../templates/working-profile-page-template.md`
+
+默认需要这些输入：
+- vault profile
+- 当前 working profile page（如果已有）
+- 本轮证据来源：当前对话、用户纠正、长期反馈、会议纪要、任务回顾等
+- 如果 profile 里没有 working profile page：用户指定目标页
+
+如果没有明确 working profile page，不要猜测文件路径。
+
+## Core rules
+
+- **只沉淀对未来协作有用的信息。**
+- **先过敏感信息过滤，再判断是否入库。**
+- **明确区分 confirmed / repeated / inferred。**
+- **单次随口表达不等于稳定画像。**
+- **允许时间变化和场景差异，不强行写成绝对人格标签。**
+- **优先更新已有 profile，不频繁新建画像页。**
+- **不写 secrets，不写高敏感个人信息，不写第三方隐私。**
+- **重大画像变化应显式写入 change note，而不是悄悄覆盖。**
+
+## What belongs in a working profile
+
+### Good candidates
+- 经多次重复出现的工作偏好
+- 用户明确表达过的协作方式偏好
+- 决策习惯与推进节奏
+- 对输出风格、结构、颗粒度的稳定要求
+- 明确的边界和禁区
+- 常见不满意点或反模式
+
+### Bad candidates
+- 一次性情绪
+- 临时状态
+- 无法验证的私人推测
+- 无助于未来合作的个人细节
+- 账号、密码、证件、地址、财务账户、医疗隐私等高敏感信息
+
+## Recommended workflow
+
+### 1. Gather evidence first
+先收集本轮真正可作为证据的材料：
+- 当前对话中的明确表达
+- 用户对你方案的修正
+- 用户多次重复过的偏好
+- 过往 working profile 中已有条目
+- 近期任务里出现的新信号
+
+### 2. Run the sensitivity gate
+先按 `references/sensitivity-boundaries.md` 过滤：
+- 哪些内容绝不应入库
+- 哪些内容需要降级成模糊描述
+- 哪些内容只适合短期上下文，不适合长期页面
+
+### 3. Extract candidate signals
+把证据转成候选画像信号，而不是直接照抄原话。
+
+优先抽这些类型：
+- Stable facts
+- Preferences
+- Decision heuristics
+- Collaboration boundaries
+- Anti-patterns
+- Open questions / provisional signals
+
+### 4. Assign evidence strength
+使用 `references/evidence-thresholds.md` 的口径：
+- `confirmed`：用户明确确认
+- `repeated`：多次稳定出现
+- `inferred`：当前可推断，但还不够稳
+
+`inferred` 项默认应更克制，必要时放到 provisional 区域，而不是写死。
+
+### 5. Update the working profile page
+默认按 `../../templates/working-profile-page-template.md` 的结构更新。
+
+写入时：
+- 保留对未来协作真正有用的表述
+- 压缩原始上下文
+- 避免人格化夸张描述
+- 保留必要 change notes
+- 避免同义重复
+
+### 6. Sync visibility surfaces carefully
+根据 profile 中的 working profile visibility 决定同步范围：
+- `maintainer-only`：只更新 profile 页面和维护入口
+- `reader-visible`：可同步 reader entrypoint 或治理入口
+- 如果未定义 visibility，默认按 `maintainer-only` 处理
+
+### 7. Validate before finishing
+检查：
+- 有没有误写高敏感信息
+- 有没有把一次性情绪写成长期标签
+- 有没有把 inferred 写成 confirmed
+- 是否保留了变化轨迹
+- 页面是否仍然可维护、可扩展、可更新
+
+## Output expectations
+
+汇报时至少说明：
+- 新增或更新了哪些 working profile 条目
+- 哪些属于 confirmed / repeated / inferred
+- 哪些候选信息被过滤掉，为什么
+- 是否记录了 change note
+- 是否同步了对应入口页
+
+## Resources
+
+### references/
+- `references/working-profile-schema.md`：working profile 推荐结构与字段边界
+- `references/evidence-thresholds.md`：如何判断 confirmed / repeated / inferred
+- `references/sensitivity-boundaries.md`：哪些个人信息绝不应入库，哪些应降级处理
+
+### templates/
+- `../../templates/vault-profile-template.md`：working profile page 与 visibility 等配置入口
+- `../../templates/working-profile-page-template.md`：推荐的 working profile 页面结构

--- a/skills/knowledge-base-working-profile/agents/openai.yaml
+++ b/skills/knowledge-base-working-profile/agents/openai.yaml
@@ -1,0 +1,6 @@
+interface:
+  display_name: "Working Profile 沉淀"
+  short_description: "从持续沟通中提炼稳定偏好、决策习惯和协作边界，写入 working profile"
+  default_prompt: "Use $knowledge-base-working-profile to update my working profile from our recent interactions. Read my vault profile first, keep only collaboration-relevant stable signals, separate confirmed from inferred items, refuse sensitive data, and sync the target profile page according to its visibility rules."
+policy:
+  allow_implicit_invocation: true

--- a/skills/knowledge-base-working-profile/references/evidence-thresholds.md
+++ b/skills/knowledge-base-working-profile/references/evidence-thresholds.md
@@ -1,0 +1,36 @@
+# Evidence Thresholds for a Working Profile
+
+## Confidence tiers
+
+### confirmed
+Use when:
+- the user explicitly confirmed the statement
+- the preference or boundary was stated directly and clearly
+
+### repeated
+Use when:
+- the same signal appears across multiple interactions
+- the signal is strong enough to guide future collaboration
+- the user may not have said it as a formal rule, but behavior is consistent
+
+### inferred
+Use when:
+- the signal is useful but still tentative
+- evidence is limited to one interaction or a weak pattern
+- the statement should remain easy to revise or remove
+
+## Practical rule
+- one clear correction may justify `confirmed`
+- two or more stable appearances may justify `repeated`
+- one-off impressions stay `inferred` or are dropped
+
+## Do not do this
+- do not turn a temporary mood into a stable label
+- do not upgrade `inferred` to `confirmed` without evidence
+- do not collapse contradictions too early
+
+## Change handling
+When a previous signal weakens or reverses:
+- do not silently overwrite it
+- add a short change note with date/context
+- keep the newer interpretation as current, but preserve the evolution if it matters

--- a/skills/knowledge-base-working-profile/references/sensitivity-boundaries.md
+++ b/skills/knowledge-base-working-profile/references/sensitivity-boundaries.md
@@ -1,0 +1,33 @@
+# Sensitivity Boundaries
+
+## Never store
+- passwords, API keys, tokens, cookies, secrets
+- ID numbers, banking details, private account credentials
+- precise home addresses or highly sensitive contact data
+- third-party private information
+- medical or legal sensitive details unless the user explicitly needs them in a safe, bounded workflow
+
+## Usually avoid
+- raw emotional moments with no long-term collaboration value
+- gossip or reputational speculation
+- highly personal details unrelated to work
+- exact timestamps or locations unless truly needed for future collaboration
+
+## Prefer safer rewrites
+Instead of storing raw detail, prefer:
+- broad collaboration-relevant wording
+- abstracted boundaries
+- role or workflow descriptions instead of personal exposure
+
+Examples:
+- not: specific private family details
+- better: prefers asynchronous work windows in the evening
+
+- not: exact financial account context
+- better: cost sensitivity matters in tool and infra choices
+
+## If unsure
+If a detail feels personal but collaboration-relevant:
+- store the minimum useful abstraction
+- avoid irreversible specificity
+- mark it as provisional when appropriate

--- a/skills/knowledge-base-working-profile/references/working-profile-schema.md
+++ b/skills/knowledge-base-working-profile/references/working-profile-schema.md
@@ -1,0 +1,49 @@
+# Working Profile Schema
+
+## Goal
+Keep a reusable collaboration profile that helps future work go faster and with less friction.
+
+## Recommended sections
+
+### 1. Stable facts
+Only work-relevant stable facts.
+Examples:
+- current focus areas
+- preferred output mediums
+- long-running project context
+
+### 2. Preferences
+Use for repeated preferences such as:
+- response style
+- level of detail
+- draft vs final preference
+- preferred structure for plans or docs
+
+### 3. Decision heuristics
+Use for stable decision tendencies, for example:
+- prefers minimum viable validation first
+- likes lightweight systems before heavy frameworks
+- wants concrete output over abstract discussion
+
+### 4. Collaboration boundaries
+Use for explicit boundaries such as:
+- ask before publishing examples
+- avoid storing sensitive details
+- do not over-assume from weak evidence
+
+### 5. Anti-patterns
+Use for repeated dislikes or failure modes.
+Examples:
+- vague recommendations
+- overlong theoretical discussion without landing
+- storing raw process noise as durable knowledge
+
+### 6. Provisional signals
+Use for inferred but not yet stable signals.
+These should remain clearly marked and easy to revise.
+
+## Writing rules
+- Prefer compact bullets over long biographies
+- Keep each item reusable in future collaboration
+- Avoid personality theater or imitation
+- Keep changes traceable over time

--- a/templates/vault-profile-template.md
+++ b/templates/vault-profile-template.md
@@ -133,3 +133,22 @@ updated: "2026-04-15"
 4. 噪音回流
 
 如需调整，可写在这里。
+
+---
+
+## 11. Working profile settings (optional but recommended)
+
+如果你希望从持续沟通中沉淀 working profile，建议补充：
+
+- Working profile page:
+- Working profile visibility: `maintainer-only` / `reader-visible`
+- Confirmation threshold for inferred items: `strict` / `medium` / `light`
+- Never-store categories（可直接列明你不希望写入长期画像的内容类型）:
+  -
+  -
+
+这部分会被 `knowledge-base-working-profile` 用来决定：
+- working profile 写到哪里
+- 哪些条目只能 maintainer 可见
+- inferred 项需要多严格才可保留
+- 哪些内容必须永远排除

--- a/templates/working-profile-page-template.md
+++ b/templates/working-profile-page-template.md
@@ -1,0 +1,54 @@
+# Working Profile Page Template
+
+> 用途：沉淀一个人在持续协作中的稳定画像。  
+> 这不是隐私档案，也不是人格模仿模板，而是帮助未来协作更顺畅的 working profile。
+
+---
+
+```yaml
+---
+title: "Working Profile - Example"
+type: "overview"
+area: "governance"
+tags: ["working-profile", "collaboration"]
+updated: "2026-04-17"
+---
+```
+
+# Working Profile
+
+## Scope
+- Visibility: maintainer-only / reader-visible
+- Last reviewed:
+- Change policy: inferred items should stay revisable
+
+---
+
+## Stable facts
+- [confirmed] 
+
+## Preferences
+- [confirmed] 
+- [repeated] 
+
+## Decision heuristics
+- [repeated] 
+
+## Collaboration boundaries
+- [confirmed] 
+
+## Anti-patterns
+- [repeated] 
+
+## Provisional signals
+- [inferred] 
+
+## Change notes
+- 2026-04-17: 
+```
+
+使用说明：
+- `confirmed`：用户明确确认
+- `repeated`：多次稳定出现
+- `inferred`：当前可推断，但仍待确认
+- 若某条已经失效，尽量在 change notes 中说明，不要直接无痕覆盖

--- a/中文封面说明页.md
+++ b/中文封面说明页.md
@@ -22,18 +22,21 @@
 
 ## 这个包里有什么
 
-### 4 个 skills
+### 5 个 skills
 1. `knowledge-base-kit-guide`
    - 安装说明 / 配置说明 / 技能分流
 2. `knowledge-base-ingest`
    - 把长 markdown / 书稿 / 教程拆分、链接并导入知识库
 3. `knowledge-base-maintenance`
    - 把任务结果沉淀进知识库
-4. `knowledge-base-audit`
+4. `knowledge-base-working-profile`
+   - 把持续沟通中的稳定偏好、决策习惯和协作边界沉淀成 working profile
+5. `knowledge-base-audit`
    - 审计知识库结构、导航、元数据和噪音回流
 
-### 1 个配置模板
+### 2 个模板
 - `templates/vault-profile-template.md`
+- `templates/working-profile-page-template.md`
 
 ### 1 套说明文档
 - `README.md`
@@ -55,7 +58,7 @@
 1. 看 `START-HERE.md`
 2. 复制 `templates/vault-profile-template.md`
 3. 填你的 vault 路径、areas、root pages、frontmatter 规则
-4. 把 4 个 skills 复制到你的 skills 目录
+4. 把 5 个 skills 复制到你的 skills 目录
 5. 第一次先用 `knowledge-base-kit-guide`
 
 ### 如果你想先了解方法论
@@ -120,6 +123,13 @@
 先读 vault profile，再按章节/主题拆分，建立导航和 related links，并同步 overview、reader entry 和 milestone log。
 ```
 
+### 想沉淀长期协作画像时可以说
+
+```text
+用 $knowledge-base-working-profile 从我们的持续沟通里更新我的 working profile。
+先读 vault profile，再只保留对未来协作有用的稳定信号，区分 confirmed / repeated / inferred，过滤敏感个人信息，并按 visibility 规则同步到目标画像页。
+```
+
 ### 想做结构体检时可以说
 
 ```text
@@ -135,7 +145,7 @@
 
 ```text
 这是一个可复用的 wiki/markdown 知识库维护包。
-先看《中文封面说明页.md》或 START-HERE.md，再复制 4 个 skills，填 vault-profile-template.md，然后先用 knowledge-base-kit-guide 上手。
+先看《中文封面说明页.md》或 START-HERE.md，再复制 5 个 skills，填 vault-profile-template.md，然后先用 knowledge-base-kit-guide 上手。
 ```
 
 ---


### PR DESCRIPTION
## Summary
- add a privacy-bounded `knowledge-base-working-profile` skill for distilling stable collaboration profiles from ongoing interactions
- add a working-profile page template plus optional vault profile settings for visibility, inferred-item thresholds, and never-store categories
- update README, START-HERE, guides, prompts, and the landing page to present the repository as a 5-skill package

## Validation
- local skill bundle structure validation
- local relative link validation