### PR TITLE
修复：Orchestrator skill 缺少 agents/openai.yaml

### DIFF
--- a/skills/knowledge-base-orchestrator/agents/openai.yaml
+++ b/skills/knowledge-base-orchestrator/agents/openai.yaml
@@ -1,0 +1,6 @@
+interface:
+  display_name: "知识库总控"
+  short_description: "一键式总控技能，自动检测环境并智能路由到对应 skills，实现零门槛上手"
+  default_prompt: "Use $knowledge-base-orchestrator to help me organize my markdown knowledge base. Auto-detect environment, deploy if needed, and route to the right skill based on my intent."
+policy:
+  allow_implicit_invocation: true


### PR DESCRIPTION
# 🔧 问题修复\n\n## 问题\n\nCI 验证失败：\n```\nskills/knowledge-base-orchestrator: missing ['agents/openai.yaml']\n```\n\n最新添加的 Orchestrator skill 缺少必需的 `agents/openai.yaml` 配置文件。\n\n## 修复\n\n添加 `skills/knowledge-base-orchestrator/agents/openai.yaml`：\n- display_name: 知识库总控\n- short_description: 一键式总控技能\n- default_prompt: 自动检测环境并智能路由\n- allow_implicit_invocation: true\n\n## 验证\n\n本地运行结构验证：\n```bash\n✅ Skill bundle structure validated.\n```