### PR TITLE
Refine README for rigorous main-repo use

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -1,53 +1,31 @@
 # Wiki Knowledge Base Share Kit
 
-[![Release](https://img.shields.io/github/v/release/zouxy111/wiki-knowledgebase-share-kit)](https://github.com/zouxy111/wiki-knowledgebase-share-kit/releases)
-[![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](./LICENSE)
-[![Repo](https://img.shields.io/badge/GitHub-zouxy111%2Fwiki--knowledgebase--share--kit-black?logo=github)](https://github.com/zouxy111/wiki-knowledgebase-share-kit)
-[![Validate](https://github.com/zouxy111/wiki-knowledgebase-share-kit/actions/workflows/validate.yml/badge.svg)](https://github.com/zouxy111/wiki-knowledgebase-share-kit/actions/workflows/validate.yml)
-
-An **8-skill knowledge-base package** for markdown / wiki / Obsidian-style vaults.  
-The goal is not to record more process logs, but to keep a vault navigable, durable, and collaboration-friendly.
-
-> **New here?** Start with [`START-HERE.md`](./START-HERE.md)
-
-**Language / 语言**: [`English README`](./README.en.md) · [`中文 README`](./README.md)
-
-## Quick links
-- [`START-HERE.md`](./START-HERE.md): 5-minute onboarding
-- [`GLOSSARY.md`](./GLOSSARY.md): core concepts
-- [`templates/vault-profile-template.md`](./templates/vault-profile-template.md): primary vault profile template
-- [`templates/working-profile-page-template.md`](./templates/working-profile-page-template.md): working-profile page template
-- [`templates/journal-profile-template.md`](./templates/journal-profile-template.md): journal profile template
-- [`docs/example-prompts.md`](./docs/example-prompts.md): copy-ready prompts
-- [`docs/customization-guide.md`](./docs/customization-guide.md): adapt the package to your own vault
-- [`examples/example-vault-profile-generic.md`](./examples/example-vault-profile-generic.md): generic profile example without personal paths
-- [`examples/case-study-pathology-ingest-iteration.md`](./examples/case-study-pathology-ingest-iteration.md): test-driven ingest case study
-- [`GitHub Pages`](https://zouxy111.github.io/wiki-knowledgebase-share-kit/): landing page
-- [`Releases`](https://github.com/zouxy111/wiki-knowledgebase-share-kit/releases): published versions
+> An **8-skill knowledge-base package** for markdown / wiki / Obsidian-style vaults.  
+> The goal is not to record more logs, but to keep a vault **navigable, role-stable, maintainable, collaboration-friendly, and auditable**.
 
 ---
-
-## Developers
-- 邹星宇
-- 杨琦
-
----
-
-![Share kit preview](./docs/assets/social-preview.png)
 
 ## 30-second overview
 
-| Typical drifting vault | Target state after adopting this kit |
+Many vault problems are not caused by a lack of writing. They come from structure drift:
+- too much content without stable entrypoints
+- root pages turning into process logs
+- long-form sources, meeting notes, and task conclusions getting mixed together
+- new collaborators not knowing where to start or which workflow to use
+
+This kit is designed to shift a vault toward the following state:
+
+| Typical problem | Target state |
 |---|---|
-| Root pages accumulate temporary execution history | Root pages return to navigation, stable boundaries, and topic entrypoints |
-| `ops` pages become chronological logs | `ops` pages become reusable symptom / root cause / fix / boundary references |
-| `log.md` turns into task replay | `log.md` stays milestone-only |
-| Content grows without stable entrypoints | Pages are discoverable from root pages or the reader entrypoint |
-| Teammates do not know which workflow to use first | Onboarding and specialist skills provide clear routing |
+| Root pages become timeline dumps | Root pages return to navigation, stable boundaries, and topic entrypoints |
+| Long documents are hard to reuse after import | Sources are split into overview / chapter / topic structures with lineage preserved |
+| Durable conclusions only exist in chat or meetings | Reusable conclusions are written back into the right pages |
+| The vault drifts but nobody knows where it is broken | Audit checks dead links, orphan pages, boundary drift, and noise regression |
+| Collaboration context is fragmented and hard to hand off | Working profile, team coordination, and journal workflows create a stable collaboration surface |
 
 In one sentence:
 
-> This kit is not for recording more logs. It is for making a vault behave like a real knowledge base again.
+> Make your markdown repository behave like a real knowledge base instead of a pile of notes you wrote once and cannot reliably find later.
 
 ---
 
@@ -56,163 +34,291 @@ In one sentence:
 The current public package contains 8 skills:
 
 1. `knowledge-base-kit-guide`
-2. `knowledge-base-ingest`
-3. `knowledge-base-maintenance`
-4. `knowledge-base-audit`
-5. `knowledge-base-orchestrator`
-6. `knowledge-base-team-coordination`
-7. `knowledge-base-working-profile`
+2. `knowledge-base-orchestrator`
+3. `knowledge-base-ingest`
+4. `knowledge-base-maintenance`
+5. `knowledge-base-audit`
+6. `knowledge-base-working-profile`
+7. `knowledge-base-team-coordination`
 8. `work-journal`
 
-Those 8 skills cover **7 capability tracks**:
+Together they cover 7 capability tracks:
+- **Onboarding / Orchestration**
+- **Ingest**
+- **Maintenance**
+- **Audit**
+- **Working profile**
+- **Team coordination**
+- **Work journal**
 
-1. **Onboarding / Orchestration**
-   - `knowledge-base-kit-guide`: installation, profile setup, skill routing
-   - `knowledge-base-orchestrator`: low-friction initializer; detect existing setup, optionally install Obsidian, create a vault skeleton, generate a profile, and recommend the next skill
-2. **Ingest**
-   - `knowledge-base-ingest`: split long-form markdown sources and treat the first import as a testable baseline
-3. **Maintenance**
-   - `knowledge-base-maintenance`: write durable conclusions back into the vault
-4. **Audit**
-   - `knowledge-base-audit`: inspect structure, navigation, metadata, and noise regression
-5. **Working profile**
-   - `knowledge-base-working-profile`: distill stable collaboration preferences and boundaries
-6. **Team coordination**
-   - `knowledge-base-team-coordination`: handle questionnaires, alignment, assignment, and decision distillation for shared projects
-7. **Work journal**
-   - `work-journal`: daily work logs, meeting notes, temporary ideas, weekly distillation
+In particular:
+- `knowledge-base-kit-guide` explains installation, profile setup, and skill routing
+- `knowledge-base-orchestrator` provides low-friction onboarding: inspect the current environment, create a vault skeleton, generate a profile, and route the user to the next specialist skill
+
+> `knowledge-base-orchestrator` is an **onboarding coordinator**, not a universal autonomous agent.
 
 ---
 
-## Best fit / not fit
+## Best fit
 
-### Best fit
-- People already maintaining an Obsidian, markdown, or wiki vault
-- Teams that want to separate durable knowledge from execution history
+### Good fit
+- Individuals or teams already maintaining a markdown / wiki / Obsidian-style vault
+- People who want to separate execution history from durable knowledge
 - Users who accept the fixed page-role model: `project / knowledge / ops / task / overview`
-- Setups that also want stable collaboration memory, shared-project coordination, or work journaling
+- Teams that want stable workflows for long-form ingest, maintenance, audit, working profile, shared-project coordination, and work journaling
 
 ### Not a good fit
-- People who do not want to configure a profile at all
-- Log-first vaults that do not care about retrieval or governance
-- Users who reject the fixed page-role model entirely
-- Anyone expecting Orchestrator to be a fully autonomous all-purpose agent
+- People who do not want to configure a `vault profile`
+- Log-first vaults that do not care about navigation or governance
+- Users expecting the package to run as a background fully automatic system
+- Setups that reject the fixed page-role model entirely
 
 ---
 
-## Platform status
+## Core model: 5 fixed page roles
 
-| Platform | Status | Notes |
+This method uses **5 fixed page roles**:
+
+| Role | Purpose | What it should not carry |
 |---|---|---|
-| Codex / ChatGPT Codex-style skill directories | Recommended | Repository includes 8 complete skill bundles with `SKILL.md`, `references/`, and `agents/openai.yaml` |
-| Claude-style skill directories | Works | Copy the 8 skill folders directly |
-| Other platforms supporting `SKILL.md` bundles | Maybe | Invocation and discovery may need adaptation |
+| `project` | project navigation, overview, boundaries | long chronological narration, raw chat history |
+| `knowledge` | methods, concepts, reusable knowledge | “what I did today” style process notes |
+| `ops` | troubleshooting, operational procedures, boundary rules | one-off fix playback |
+| `task` | todo items, assignments, in-progress work | long-term knowledge |
+| `overview` | vault homepage, governance rules, indexes | detailed project history |
+
+Additional note:
+- `work-journal` is a **separate workflow**, not a sixth fixed page role
+- journal content should be filtered before it is promoted into `knowledge`, `ops`, `project`, or other stable pages
 
 ---
 
-## Repository layout
-```text
-wiki-knowledgebase-share-kit/
-  START-HERE.md
-  COVER-CN.md
-  GLOSSARY.md
-  README.md
-  README.en.md
-  docs/
-  templates/
-    vault-profile-template.md
-    working-profile-page-template.md
-    journal-profile-template.md
-    member-capability-profile-template.md
-    ingest-iteration-log-template.md
-  examples/
-    example-vault-profile-generic.md
-    scenario-*.md
-  skills/
-    knowledge-base-kit-guide/
-    knowledge-base-ingest/
-    knowledge-base-maintenance/
-    knowledge-base-audit/
-    knowledge-base-orchestrator/
-    knowledge-base-team-coordination/
-    knowledge-base-working-profile/
-    work-journal/
-```
+## Why this method works
 
-### About `examples/`
-- `example-vault-profile*.md` and case studies are closer to real reuse
-- `scenario-*.md` files are **scenario-only demonstrations**; some page links inside them are intentionally hypothetical and do not correspond to real repo files
+It relies on a few fixed rules:
+
+1. **Knowledge-base-first**: keep durable knowledge, filter one-off noise
+2. **Fixed role model**: each page has a clear job
+3. **Four-sync mechanism**: substantive updates should sync the target page, root page, `index.md`, and `log.md`
+4. **Milestone-only log**: `log.md` should record milestones, not task playback
+5. **Periodic audit**: structure, navigation, metadata, and noise regression should be checked on a regular basis
 
 ---
 
-## Recommended installation
+## Recommended scenario: high-knowledge-density, multi-person, auditable collaboration
 
-Copy these 8 directories into your AI platform's `skills/` folder:
+This kit is particularly strong in a class of environments that are:
 
-- `skills/knowledge-base-kit-guide`
-- `skills/knowledge-base-ingest`
-- `skills/knowledge-base-maintenance`
-- `skills/knowledge-base-audit`
-- `skills/knowledge-base-orchestrator`
-- `skills/knowledge-base-team-coordination`
-- `skills/knowledge-base-working-profile`
-- `skills/work-journal`
+> **knowledge-dense, frequently updated, collaboration-heavy, and in need of traceability and auditability.**
 
-Common locations:
-- `~/.codex/skills`
-- `~/.claude/skills`
+That includes, but is not limited to:
+- medical / pathology / research work
+- enterprise knowledge bases / project delivery / operational documentation
+- cross-team collaboration / onboarding / meeting conclusion distillation
 
-Then prepare at least your `vault profile` before day-to-day use.
+These settings look different, but the underlying problems are often similar:
+
+| Shared problem | In medical / research work | In enterprise / team work |
+|---|---|---|
+| Long-form sources are hard to reuse | guidelines, textbooks, papers, case summaries are hard to retrieve | PRDs, solution docs, runbooks, and meeting materials are hard to revisit |
+| Experience is scattered | clinical or research experience lives in fragmented notes | project experience is scattered across chat, meeting notes, and temporary docs |
+| Collaboration is complex | advisors, colleagues, and collaborators are hard to keep aligned | cross-functional teams keep repeating context and background |
+| Boundaries and auditability matter | content cannot be mixed casually and updates must stay controlled | governance needs clear navigation, ownership, and audit findings |
+
+So this is better understood as **one method for high-knowledge-density collaboration**, not as separate “medical” and “enterprise” products.
+
+---
+
+## How the kit is used in that scenario
+
+### 1. Import long-form sources, books, guidelines, or plans
+Use `knowledge-base-ingest` to:
+- read the `vault profile`
+- split the source into overview / chapter / topic pages
+- generate TOC, glossary candidates, and related-link suggestions
+- treat the first import as a **testable baseline** and improve it through iteration and regression checks
+
+Typical examples:
+- medical books, guidelines, papers
+- enterprise SOPs, PRDs, delivery docs, training materials
+
+### 2. Distill durable task results and meeting conclusions
+Use `knowledge-base-maintenance` to:
+- extract stable conclusions from tasks, meetings, conversations, or deliverables
+- filter one-off process noise
+- update the target page and the related navigation surfaces
+
+### 3. Perform periodic structural governance
+Use `knowledge-base-audit` to:
+- inspect dead links, orphan pages, and missing entrypoints
+- detect page-boundary drift, metadata issues, and stray root-level files
+- report traceable P1 / P2 / P3 findings
+
+### 4. Maintain collaboration context and shared-project structure
+Use:
+- `knowledge-base-working-profile`
+- `knowledge-base-team-coordination`
+- `work-journal`
+
+The goal here is **not** to create a private dossier. The goal is to:
+- distill stable signals that matter for future collaboration
+- separate `confirmed / repeated / inferred` items
+- filter sensitive personal data and anything that should not be stored long term
+- keep draft / approved boundaries in shared coordination workflows
+
+---
+
+## Working profile boundaries matter
+
+`knowledge-base-working-profile` maintains a **working profile**, not a personal surveillance record.
+
+It focuses on:
+- stable preferences
+- decision heuristics
+- collaboration boundaries
+- anti-patterns
+- stable signals that directly improve future collaboration
+
+It should not retain by default:
+- highly sensitive personal data
+- private details unrelated to future collaboration
+- third-party private information
+- strong unconfirmed inference
+- one-off emotional reactions
+
+In team, medical, or otherwise sensitive settings, the README should make these boundaries explicit:
+- consent
+- visibility
+- share only what is necessary
+- confirm first, then promote to durable profile material
 
 ---
 
 ## Recommended usage order
 
-### If you want the easiest start
-- Start with `knowledge-base-orchestrator`
-- It first checks whether you already have an existing Obsidian / vault / profile setup
-- Optional Obsidian installation is exactly that: **optional**, not the core value of the repository
-- After initialization, it routes you to the right next specialist skill
+### If you are completely new
+1. Start with `START-HERE.md`
+2. Prepare `templates/vault-profile-template.md`
+3. Use `knowledge-base-orchestrator` for onboarding
+4. Then move into the relevant specialist skill
 
-### If you want to understand the package first
-- Start with `knowledge-base-kit-guide`
-- It explains the profile, installation shape, and which skill to call next
+### If you want to understand the method first
+1. Start with `knowledge-base-kit-guide`
+2. Understand the profile, role model, and routing
+3. Then choose ingest / maintenance / audit / working-profile / team-coordination / journal as needed
 
-### Day-to-day routing
-- Long-form import: `knowledge-base-ingest`
-- Durable task result: `knowledge-base-maintenance`
-- Structural review: `knowledge-base-audit`
-- Collaboration profile distillation: `knowledge-base-working-profile`
-- Shared project coordination: `knowledge-base-team-coordination`
-- Daily work notes / weekly summary: `work-journal`
+### If you already know what you need
+Go directly to the relevant specialist skill:
+- long-form import: `knowledge-base-ingest`
+- durable maintenance: `knowledge-base-maintenance`
+- structural review: `knowledge-base-audit`
+- collaboration profile update: `knowledge-base-working-profile`
+- shared-project coordination: `knowledge-base-team-coordination`
+- daily work logging: `work-journal`
 
 ---
 
-## Fixed rules of the method
-- knowledge-base-first, not process-log-first
-- fixed page-role model: `project / knowledge / ops / task / overview`
-- root pages are for navigation and stable overview
-- `ops` pages default to symptom / root cause / fix / boundary
-- milestone logs should not become task playback logs
-- durable maintenance should update both content and navigation surfaces
+## Installation
+
+Start with the general rule:
+
+> The package is fundamentally a set of **8 `SKILL.md`-style skill bundles**.  
+> If your AI platform supports a similar skills directory structure, you can install it. Directory locations vary by platform.
+
+Common examples:
+
+```bash
+cp -r skills/knowledge-base-kit-guide ~/.codex/skills/
+cp -r skills/knowledge-base-orchestrator ~/.codex/skills/
+cp -r skills/knowledge-base-ingest ~/.codex/skills/
+cp -r skills/knowledge-base-maintenance ~/.codex/skills/
+cp -r skills/knowledge-base-audit ~/.codex/skills/
+cp -r skills/knowledge-base-working-profile ~/.codex/skills/
+cp -r skills/knowledge-base-team-coordination ~/.codex/skills/
+cp -r skills/work-journal ~/.codex/skills/
+```
+
+Other common directory patterns include:
+- `~/.codex/skills`
+- `~/.claude/skills`
+- or another platform-specific location for `SKILL.md` bundles
+
+> If you are using OpenClaw, Hermes Agent, Claude Code, or another compatible platform, confirm that platform’s skill-directory convention before installation.
+
+---
+
+## OpenClaw / Hermes / MinerU compatibility notes
+
+This method often pairs well with:
+- **OpenClaw** as a day-to-day AI assistant platform
+- **Hermes Agent** as a long-running collaboration-oriented agent platform
+- **MinerU** as a PDF / complex-document to markdown conversion tool
+
+But the important boundary is:
+- these are **recommended combinations**, not exclusive dependencies
+- the core value of this repository is still **knowledge-base structure governance and workflow design**, not platform lock-in
+
+---
+
+## Quick start
+
+```bash
+# 1. Clone the repository
+git clone https://github.com/zouxy111/wiki-knowledgebase-share-kit.git
+cd wiki-knowledgebase-share-kit
+
+# 2. Read the onboarding entrypoint
+cat START-HERE.md
+
+# 3. Copy the template and prepare your profile
+cp templates/vault-profile-template.md ./my-vault-profile.md
+```
+
+Once your platform and skill directory are ready, install the 8 skill bundles.
+
+---
+
+## FAQ
+
+**Q: Can I use this without Obsidian?**  
+A: Yes. If you have a markdown/wiki vault and a platform that supports the relevant skill structure, you can use it.
+
+**Q: Can I use it without full automation?**  
+A: Yes. The docs, templates, and checklists are still usable manually; the skills mainly improve execution efficiency.
+
+**Q: My vault is already messy. Can I still adopt this?**  
+A: Yes. Start with an audit, then fix structure, repair navigation, and tighten page boundaries incrementally.
+
+**Q: Are enterprise and medical separate solutions?**  
+A: No. They are two common variants of the same broader scenario: high-knowledge-density, multi-person, auditable collaboration.
+
+**Q: Will the working profile become a privacy dossier?**  
+A: It should not. The intended use is to keep collaboration-relevant stable signals while enforcing consent, visibility, and sensitive-data filtering boundaries.
 
 ---
 
 ## Read these first
 
-Shortest path:
 - `START-HERE.md`
 - `GLOSSARY.md`
 - `templates/vault-profile-template.md`
 - `docs/example-prompts.md`
 - `docs/usage-sop.md`
-
-If you want to go deeper:
-- `docs/customization-guide.md`
-- `templates/working-profile-page-template.md`
-- `templates/journal-profile-template.md`
-- `templates/member-capability-profile-template.md`
 - `examples/case-study-pathology-ingest-iteration.md`
 
+---
+
+## Need help?
+
+- [GitHub Issues](https://github.com/zouxy111/wiki-knowledgebase-share-kit/issues)
+- Developers: 邹星宇, 杨琦
+
+---
+
 ## License
-Released under the MIT License. See `/LICENSE`.
+
+MIT License
+
+---
+
+> If you want your vault to behave more like a knowledge base and less like a note dump, start with `START-HERE.md`.

--- a/README.md
+++ b/README.md
@@ -1,53 +1,31 @@
 # Wiki Knowledge Base Share Kit
 
-[![Release](https://img.shields.io/github/v/release/zouxy111/wiki-knowledgebase-share-kit)](https://github.com/zouxy111/wiki-knowledgebase-share-kit/releases)
-[![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](./LICENSE)
-[![Repo](https://img.shields.io/badge/GitHub-zouxy111%2Fwiki--knowledgebase--share--kit-black?logo=github)](https://github.com/zouxy111/wiki-knowledgebase-share-kit)
-[![Validate](https://github.com/zouxy111/wiki-knowledgebase-share-kit/actions/workflows/validate.yml/badge.svg)](https://github.com/zouxy111/wiki-knowledgebase-share-kit/actions/workflows/validate.yml)
-
-一套面向 markdown / wiki / Obsidian vault 的**8-skill 知识库维护包**。  
-目标不是继续堆日志，而是把知识库收敛成：**入口清楚、页面角色稳定、长期可维护、对多人协作友好**。
-
-> **完全新手先看：** [`START-HERE.md`](./START-HERE.md)
-
-**语言 / Language**：[`中文 README`](./README.md) · [`English README`](./README.en.md)
-
-## 快速入口
-- [`START-HERE.md`](./START-HERE.md)：5 分钟快速上手
-- [`GLOSSARY.md`](./GLOSSARY.md)：核心概念解释
-- [`templates/vault-profile-template.md`](./templates/vault-profile-template.md)：主配置模板
-- [`templates/working-profile-page-template.md`](./templates/working-profile-page-template.md)：working profile 页面模板
-- [`templates/journal-profile-template.md`](./templates/journal-profile-template.md)：journal 配置模板
-- [`docs/example-prompts.md`](./docs/example-prompts.md)：可直接复制的提示词
-- [`docs/customization-guide.md`](./docs/customization-guide.md)：如何适配自己的 vault
-- [`examples/example-vault-profile-generic.md`](./examples/example-vault-profile-generic.md)：不带个人路径的通用 profile 示例
-- [`examples/case-study-pathology-ingest-iteration.md`](./examples/case-study-pathology-ingest-iteration.md)：测试驱动的长文档导入案例
-- [`GitHub Pages`](https://zouxy111.github.io/wiki-knowledgebase-share-kit/)：在线落地页
-- [`Releases`](https://github.com/zouxy111/wiki-knowledgebase-share-kit/releases)：下载已发布版本
+> 一套面向 markdown / wiki / Obsidian-style vault 的 **8-skill 知识库维护包**。  
+> 目标不是堆更多日志，而是把知识库收敛成：**入口清楚、页面角色稳定、长期可维护、对协作友好、可审计**。
 
 ---
 
-## 开发者
-- 邹星宇
-- 杨琦
+## 30 秒看懂
 
----
+很多知识库的问题，不是“没写”，而是：
+- 写了很多，但没有稳定入口
+- 根页越写越像流水账
+- 长文档、会议纪要、任务结论混在一起
+- 新人或协作者不知道先看哪里，也不知道该用哪个 workflow
 
-![Share kit preview](./docs/assets/social-preview.png)
+这套 kit 要解决的是：
 
-## 30 秒看懂这套 kit
-
-| 你现在的 vault 可能是 | 用完这套 kit 后希望变成 |
+| 典型问题 | 目标状态 |
 |---|---|
-| 根页堆了很多执行过程和临时记录 | 根页只保留导航、稳定边界、专题入口 |
-| `ops` 页越写越像按天流水账 | `ops` 页沉淀成“现象 / 根因 / 处理法 / 边界” |
-| `log.md` 变成任务回放 | `log.md` 只保留 milestone 级变化 |
-| 内容页越来越多，但没有稳定入口 | 页面必须被 root page / reader entry 收录 |
-| 新人或协作者不知道先用哪个 skill | 先走 onboarding，再进入明确分流 |
+| 根页越来越像流水账 | 根页只保留导航、稳定边界、专题入口 |
+| 长文档导入后很难复用 | 拆成 overview / chapter / topic 结构，并保留来源链 |
+| 任务结果只存在聊天里 | 把可复用结论沉淀到合适页面 |
+| 知识库乱了却没人知道哪里坏了 | 用 audit 定期检查死链、孤页、边界漂移、噪音回流 |
+| 协作信息零散、不好交接 | 用 working profile、team coordination、journal 形成稳定协作面 |
 
 一句话说：
 
-> 这不是“帮你多记日志”的包，而是“把知识库重新写得像知识库”的包。
+> 让你的 markdown 仓库更像知识库，而不是“写过但以后找不到”的资料堆。
 
 ---
 
@@ -56,167 +34,291 @@
 当前正式包包含 8 个 skill：
 
 1. `knowledge-base-kit-guide`
-2. `knowledge-base-ingest`
-3. `knowledge-base-maintenance`
-4. `knowledge-base-audit`
-5. `knowledge-base-orchestrator`
-6. `knowledge-base-team-coordination`
-7. `knowledge-base-working-profile`
+2. `knowledge-base-orchestrator`
+3. `knowledge-base-ingest`
+4. `knowledge-base-maintenance`
+5. `knowledge-base-audit`
+6. `knowledge-base-working-profile`
+7. `knowledge-base-team-coordination`
 8. `work-journal`
 
-这 8 个 skill 共同覆盖 **7 条能力线**：
+它们共同覆盖 7 条能力线：
+- **Onboarding / Orchestration**
+- **Ingest**
+- **Maintenance**
+- **Audit**
+- **Working profile**
+- **Team coordination**
+- **Work journal**
 
-1. **Onboarding / Orchestration**
-   - `knowledge-base-kit-guide`：解释安装、profile 配置、技能分流
-   - `knowledge-base-orchestrator`：零门槛初始化入口；检测现有环境、可选安装 Obsidian、创建骨架、生成 profile，并给出下一步 skill 路由
-2. **Ingest**
-   - `knowledge-base-ingest`：拆分长 markdown / 书稿 / 教程，并把第一次导入作为可测试基线
-3. **Maintenance**
-   - `knowledge-base-maintenance`：把任务结果或结论沉淀进知识库
-4. **Audit**
-   - `knowledge-base-audit`：检查结构、导航、元数据和噪音回流
-5. **Working profile**
-   - `knowledge-base-working-profile`：从持续沟通中提炼稳定协作画像
-6. **Team coordination**
-   - `knowledge-base-team-coordination`：面向多人项目的问卷、对齐、派单和决策蒸馏
-7. **Work journal**
-   - `work-journal`：记录每日工作、会议纪要、临时想法，并支持周报/沉淀
+其中：
+- `knowledge-base-kit-guide` 负责解释安装、profile 配置、技能分流
+- `knowledge-base-orchestrator` 负责低门槛初始化：检查现有环境、创建骨架、生成 profile、推荐下一步 specialist skill
+
+> `knowledge-base-orchestrator` 是 **onboarding coordinator**，不是“万能自动代理”。
 
 ---
 
-## 适合谁 / 不适合谁
+## 适合谁
 
 ### 适合
-- 已经在维护 Obsidian / markdown / wiki vault 的个人或团队
+- 已经在维护 markdown / wiki / Obsidian vault 的个人或团队
 - 想把“任务过程”和“长期知识”拆开的使用者
-- 接受固定页面角色模型：`project / knowledge / ops / task / overview`
-- 想给长期协作画像、多人项目协调、工作记录建立稳定入口的人
+- 接受固定 page-role model：`project / knowledge / ops / task / overview`
+- 想为长文档导入、知识沉淀、协作画像、团队协调、工作记录建立稳定 workflow 的人
 
 ### 不太适合
-- 完全不想配置 profile 的人
+- 完全不想配置 `vault profile` 的人
 - 只想保留日志式记录、不关心导航治理的人
+- 期待系统默认后台全自动运行的人
 - 不接受固定页面角色模型的人
-- 希望把 Orchestrator 当成“万能自动代理”的人
 
 ---
 
-## 支持平台状态
+## 核心模型：5 个固定页面角色
 
-| 平台 | 状态 | 说明 |
+这套方法使用 **5 个固定 page roles**：
+
+| 角色 | 用途 | 不该承载什么 |
 |---|---|---|
-| Codex / ChatGPT Codex 风格 skills 目录 | 推荐 | 仓库包含 8 个完整 skill bundle，每个都有 `SKILL.md`、`references/`、`agents/openai.yaml` |
-| Claude 风格 skills 目录 | 可用 | 直接复制 8 个 skill 目录即可 |
-| 其他支持 `SKILL.md` 目录结构的平台 | 可能可用 | 需自行适配 skill 发现与调用方式 |
+| `project` | 项目导航、总览、边界 | 长流水、临时聊天记录 |
+| `knowledge` | 方法、概念、可复用知识 | “今天做了什么”式过程记录 |
+| `ops` | 排障手册、操作流程、边界说明 | 单次修复回放 |
+| `task` | 待办、分工、进行中任务 | 长期知识沉淀 |
+| `overview` | 知识库首页、治理规则、索引 | 项目历史细节 |
 
-如果你不确定平台兼容性，先看：
-- `START-HERE.md`
-- `docs/usage-sop.md`
-
----
-
-## 包内结构
-
-```text
-wiki-knowledgebase-share-kit/
-  COVER-CN.md
-  START-HERE.md
-  GLOSSARY.md
-  README.md
-  README.en.md
-  docs/
-  templates/
-    vault-profile-template.md
-    working-profile-page-template.md
-    journal-profile-template.md
-    member-capability-profile-template.md
-    ingest-iteration-log-template.md
-  examples/
-    example-vault-profile-generic.md
-    scenario-*.md
-  skills/
-    knowledge-base-kit-guide/
-    knowledge-base-ingest/
-    knowledge-base-maintenance/
-    knowledge-base-audit/
-    knowledge-base-orchestrator/
-    knowledge-base-team-coordination/
-    knowledge-base-working-profile/
-    work-journal/
-```
-
-### `examples/` 的说明
-- `example-vault-profile*.md` 和 case study 更接近真实落地
-- `scenario-*.md` 是**场景化示意**，其中出现的页面链接和目录结构可能是假设性示例，不等于仓库真实文件
+补充说明：
+- `work-journal` 是**独立 workflow**，不是第 6 个固定 page role
+- journal 里的内容需要经过筛选后，才应进入 `knowledge` / `ops` / `project` 等稳定页面
 
 ---
 
-## 推荐安装方式
+## 为什么这套方法有效
 
-把以下 8 个目录复制到你的 skills 目录：
+它依赖几个固定原则：
 
-- `skills/knowledge-base-kit-guide`
-- `skills/knowledge-base-ingest`
-- `skills/knowledge-base-maintenance`
-- `skills/knowledge-base-audit`
-- `skills/knowledge-base-orchestrator`
-- `skills/knowledge-base-team-coordination`
-- `skills/knowledge-base-working-profile`
-- `skills/work-journal`
+1. **Knowledge-base-first**：只保留长期有用的内容，过滤一次性噪音
+2. **固定角色模型**：每个页面都有清晰职责，避免混写
+3. **四同步机制**：每次实质更新至少同步目标页、root page、`index.md`、`log.md`
+4. **Milestone-only log**：`log.md` 只记录里程碑，不写任务回放
+5. **定期审计**：周期性检查结构、导航、元数据和噪音回流
 
-常见位置示例：
-- `~/.codex/skills`
-- `~/.claude/skills`
+---
 
-安装后，至少准备好自己的 `vault profile`，再进入日常使用。
+## 推荐场景：高知识密度 + 多人协作 + 可审计
+
+这套 kit 特别适合一类场景：
+
+> **知识密度高、更新频繁、协作复杂、又需要可追溯和可审计的工作环境。**
+
+这包括但不限于：
+- 医疗 / 病理 / 科研
+- 企业知识库 / 项目交付 / 运维文档
+- 跨团队协作 / 新人 onboarding / 会议结论沉淀
+
+这些场景看上去不同，但底层问题很像：
+
+| 共同问题 | 在医疗/科研里的表现 | 在企业/团队里的表现 |
+|---|---|---|
+| 长文档多，复用难 | 指南、教材、文献、病例总结难检索 | PRD、方案、操作手册、会议材料难回查 |
+| 经验零散 | 临床/科研经验散在笔记里 | 项目经验散在聊天、会议纪要、临时文档里 |
+| 人员协作复杂 | 导师、同事、研究伙伴的信息难追踪 | 跨部门、跨角色协作要反复同步背景 |
+| 需要边界和可审计性 | 内容不能随意混写，更新要谨慎 | 团队治理需要清楚的导航、责任和审计结果 |
+
+所以更准确地说，这不是“医生版”和“企业版”两个不同产品；而是同一套方法在 **高知识密度协作场景** 下的两种常见落地。
+
+---
+
+## 这套 kit 在这个场景里怎么用
+
+### 1. 导入长文档 / 书籍 / 指南 / 方案
+使用 `knowledge-base-ingest`：
+- 先读 `vault profile`
+- 把长 source 拆成 overview / chapter / topic
+- 建立 toc、glossary candidates、related-link suggestions
+- 把第一版导入当成 **可测试基线**，通过迭代和回归继续优化结构
+
+适合：
+- 医学书籍 / 指南 / 文献整理
+- 企业 SOP / PRD / 交付文档 / 培训资料整理
+
+### 2. 沉淀任务结果和会议结论
+使用 `knowledge-base-maintenance`：
+- 从任务、会议、对话、交付物中提炼稳定结论
+- 过滤一次性过程噪音
+- 更新目标页面，并同步导航入口和里程碑日志
+
+### 3. 做周期性结构治理
+使用 `knowledge-base-audit`：
+- 检查 dead links、orphan pages、missing entrypoints
+- 检查 page-boundary drift、metadata 问题、root-level stray files
+- 输出可追溯的 P1 / P2 / P3 findings
+
+### 4. 维护协作画像和共享项目上下文
+使用：
+- `knowledge-base-working-profile`
+- `knowledge-base-team-coordination`
+- `work-journal`
+
+这里的目标不是“自动建私人档案”，而是：
+- 只提炼**对未来协作有用**的稳定信号
+- 区分 `confirmed / repeated / inferred`
+- 过滤敏感个人信息与不应长期保存的内容
+- 在共享项目中保持 draft / approved 边界
+
+---
+
+## 关于 working profile：边界要说清楚
+
+`knowledge-base-working-profile` 沉淀的是 **working profile**，不是私人档案系统。
+
+它关注的是：
+- 稳定偏好
+- 决策习惯
+- 协作边界
+- 反模式
+- 与未来协作直接相关的稳定信号
+
+默认不应长期保存：
+- 高敏感个人信息
+- 与未来协作无关的私人细节
+- 第三方隐私
+- 未经确认的强推断
+- 一次性情绪表达
+
+如果涉及共享、团队、医疗等敏感场景，应该额外强调：
+- consent
+- visibility
+- 只共享必要信息
+- 先确认，再升级为稳定画像
 
 ---
 
 ## 推荐使用顺序
 
 ### 完全新手
-- 先用 `knowledge-base-orchestrator`
-- 它会优先检测你是否已经有现成的 Obsidian / vault / profile
-- 如需安装 Obsidian，默认是**可选步骤**，不是必须步骤
-- 初始化完成后，再进入具体 skill
+1. 先看 `START-HERE.md`
+2. 准备 `templates/vault-profile-template.md`
+3. 用 `knowledge-base-orchestrator` 完成初始化
+4. 再进入 specialist skill
 
-### 想手动理解和配置
-- 先用 `knowledge-base-kit-guide`
-- 它负责解释 profile、安装方式、以及后续该调用哪个 skill
+### 想先理解方法再动手
+1. 先用 `knowledge-base-kit-guide`
+2. 理解 profile、角色模型、技能分流
+3. 再选择 ingest / maintenance / audit / working-profile / team-coordination / journal
 
-### 日常分流
-- 要导入长文档 / 书籍 / 教程：`knowledge-base-ingest`
-- 要沉淀任务结果：`knowledge-base-maintenance`
-- 要做结构体检：`knowledge-base-audit`
-- 要沉淀长期协作画像：`knowledge-base-working-profile`
-- 要协调多人共享项目：`knowledge-base-team-coordination`
-- 要记每日工作 / 会议 / 周报：`work-journal`
-
----
-
-## 这套方法的固定部分
-
-以下内容默认固定，不建议轻易改掉：
-- 知识库优先，不收一次性过程噪音
-- 页面角色模型：`project / knowledge / ops / task / overview`
-- 根页只做导航和稳定总览
-- `ops` 页默认写成“现象 / 根因 / 处理法 / 边界”
-- `log.md` 只写里程碑，不写任务回放
-- 实质维护要同步内容页与导航入口
+### 已经知道自己要做什么
+直接进入对应 specialist skill：
+- 导入长文档：`knowledge-base-ingest`
+- 沉淀任务结果：`knowledge-base-maintenance`
+- 做结构体检：`knowledge-base-audit`
+- 更新协作画像：`knowledge-base-working-profile`
+- 协调共享项目：`knowledge-base-team-coordination`
+- 记录日常工作：`work-journal`
 
 ---
 
-## 先读哪几个文件
+## 安装方式
 
-最短路径：
-- `START-HERE.md` — 新手入口
-- `GLOSSARY.md` — 概念解释
-- `templates/vault-profile-template.md` — 主配置模板
-- `docs/example-prompts.md` — 第一批可直接复制的提示词
-- `docs/usage-sop.md` — 8 个 skill 的职责与分流
+先说原则：
 
-如果你想继续深入：
-- `docs/customization-guide.md`
-- `templates/working-profile-page-template.md`
-- `templates/journal-profile-template.md`
-- `templates/member-capability-profile-template.md`
+> 这套包本质上是 **8 个 `SKILL.md` 风格 skill bundle**。  
+> 只要你的 AI 平台支持类似 skills 目录结构，就可以安装；不同平台的目录位置可能不同。
+
+常见示例：
+
+```bash
+cp -r skills/knowledge-base-kit-guide ~/.codex/skills/
+cp -r skills/knowledge-base-orchestrator ~/.codex/skills/
+cp -r skills/knowledge-base-ingest ~/.codex/skills/
+cp -r skills/knowledge-base-maintenance ~/.codex/skills/
+cp -r skills/knowledge-base-audit ~/.codex/skills/
+cp -r skills/knowledge-base-working-profile ~/.codex/skills/
+cp -r skills/knowledge-base-team-coordination ~/.codex/skills/
+cp -r skills/work-journal ~/.codex/skills/
+```
+
+也可按平台改到：
+- `~/.codex/skills`
+- `~/.claude/skills`
+- 或其他支持 `SKILL.md` bundle 的平台目录
+
+> 如果你使用 OpenClaw、Hermes Agent、Claude Code 或其他兼容平台，请先确认该平台的 skills 目录约定，再安装。
+
+---
+
+## OpenClaw / Hermes / MinerU 适配说明
+
+这套方法和以下工具组合时通常会更顺手：
+- **OpenClaw**：适合作为日常 AI 助手运行平台
+- **Hermes Agent**：适合作为可持续协作与成长型 agent 平台
+- **MinerU**：适合把 PDF / 复杂文档转成 LLM 可处理的 markdown
+
+但要注意：
+- 这些平台/工具是**推荐组合**，不是本仓库唯一依赖
+- 本仓库的核心价值仍然是 **知识库结构治理与 workflow 设计**，不是平台绑定
+
+---
+
+## 快速上手
+
+```bash
+# 1. 克隆仓库
+git clone https://github.com/zouxy111/wiki-knowledgebase-share-kit.git
+cd wiki-knowledgebase-share-kit
+
+# 2. 先看新手入口
+cat START-HERE.md
+
+# 3. 复制模板并准备 profile
+cp templates/vault-profile-template.md ./my-vault-profile.md
+```
+
+如果你已经准备好平台和 skills 目录，再安装 8 个 skill bundle。
+
+---
+
+## 常见问题
+
+**Q：我不用 Obsidian，能用吗？**  
+A：能。只要你有 markdown/wiki vault，并且平台支持相应 skill 目录结构，就可以用。
+
+**Q：我不想全自动，只想按规则手动整理，能用吗？**  
+A：能。你可以直接使用文档、模板和 checklist；AI 只是提高执行效率。
+
+**Q：我已经有很多旧笔记了，还能用吗？**  
+A：能。建议先跑一次 audit，再逐步修结构、补导航、收敛页面边界。
+
+**Q：企业和医疗是不是两套完全不同的方案？**  
+A：不是。它们都属于“高知识密度 + 多人协作 + 可审计”的场景，只是资料类型和协作方式不同。
+
+**Q：working profile 会不会变成隐私档案？**  
+A：不应该。正确做法是只保留协作相关的稳定信号，并明确 consent、visibility 和敏感信息过滤边界。
+
+---
+
+## 建议先读哪些文件
+
+- `START-HERE.md`
+- `GLOSSARY.md`
+- `templates/vault-profile-template.md`
+- `docs/example-prompts.md`
+- `docs/usage-sop.md`
 - `examples/case-study-pathology-ingest-iteration.md`
+
+---
+
+## 需要帮助？
+
+- [GitHub Issues](https://github.com/zouxy111/wiki-knowledgebase-share-kit/issues)
+- 开发者：邹星宇、杨琦
+
+---
+
+## License
+
+MIT License
+
+---
+
+> 如果你想让知识库更像知识库，而不是更像资料堆，先从 `START-HERE.md` 开始。


### PR DESCRIPTION
## Summary
- replace the Chinese main README with a more rigorous repo-facing version
- merge the previous separate enterprise/medical framing into one unified scenario: high-knowledge-density, multi-person, auditable collaboration
- remove over-automation, privacy-risk, and mixed-contract wording from the previous draft

## What changed
- kept the README aligned with the current 8-skill package
- kept the fixed 5-role page model consistent with the current repository contract
- clarified that `work-journal` is a separate workflow, not a sixth page role
- reframed Orchestrator as onboarding coordinator rather than a universal autonomous agent
- tightened working-profile language around consent, visibility, sensitive data filtering, and confirmed/repeated/inferred boundaries
- rewrote the scenario section so enterprise + medical are presented as two variants of the same high-knowledge-density collaboration use case
- removed fast-aging star-count copy and unsupported “real customer case” style claims

## Scope
- only `README.md`

## Validation
- README sanity checks passed locally
