### PR TITLE
Add community governance docs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,75 @@
+name: Bug report
+description: Report a bug in docs, templates, skill metadata, scripts, or workflow behavior.
+title: "[Bug]: "
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for filing a bug report. Please provide enough detail for someone else to reproduce the problem.
+  - type: dropdown
+    id: area
+    attributes:
+      label: Affected area
+      options:
+        - README / docs
+        - Template files
+        - Skill metadata
+        - Helper scripts
+        - Onboarding / Orchestrator
+        - Ingest
+        - Maintenance
+        - Audit
+        - Working profile
+        - Team coordination
+        - Work journal
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: summary
+    attributes:
+      label: What happened?
+      description: Describe the bug clearly and concisely.
+      placeholder: The expected workflow was..., but instead...
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: List the minimal steps needed to reproduce the issue.
+      placeholder: |
+        1. Go to ...
+        2. Run ...
+        3. Observe ...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      placeholder: What did you expect to happen?
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: Environment / platform context
+      description: Include platform, skill host, OS, and any relevant file paths or versions.
+      placeholder: Codex on macOS, using ~/.codex/skills, latest main, vault profile at ...
+  - type: textarea
+    id: files
+    attributes:
+      label: Relevant files or screenshots
+      description: Add links, file paths, screenshots, or snippets if useful.
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Before submitting
+      options:
+        - label: I checked that this is not already covered by an open issue.
+          required: true
+        - label: I removed secrets, tokens, and private data from this report.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Security report
+    url: https://github.com/zouxy111/wiki-knowledgebase-share-kit/security
+    about: Use private vulnerability reporting if available. Do not post sensitive exploit details publicly.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,62 @@
+name: Feature request
+description: Suggest an improvement to docs, templates, workflows, or skills.
+title: "[Feature]: "
+labels:
+  - enhancement
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting an improvement. Please focus on reuse, clarity, maintainability, or workflow quality.
+  - type: dropdown
+    id: area
+    attributes:
+      label: Requested area
+      options:
+        - README / docs
+        - Template files
+        - Skill metadata
+        - Helper scripts
+        - Onboarding / Orchestrator
+        - Ingest
+        - Maintenance
+        - Audit
+        - Working profile
+        - Team coordination
+        - Work journal
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem does this solve?
+      description: Describe the current limitation, pain point, or gap.
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed change
+      description: Describe the feature or improvement you want.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Describe any workarounds or alternative approaches you have considered.
+  - type: textarea
+    id: impact
+    attributes:
+      label: Expected impact
+      description: Explain how this would improve reuse, onboarding, governance, or workflow quality.
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Before submitting
+      options:
+        - label: I checked existing issues and pull requests for similar requests.
+          required: true
+        - label: This request does not depend on storing secrets or unsafe personal data.
+          required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,30 @@
+## Summary
+
+- what changed
+- why it changed
+- which workflow, doc surface, template, or skill is affected
+
+## Scope
+
+- [ ] docs only
+- [ ] templates
+- [ ] skill metadata
+- [ ] helper scripts
+- [ ] tests
+- [ ] breaking change
+
+## Validation
+
+Describe what you checked locally. Examples:
+- relative links
+- skill bundle structure
+- script dry-run
+- screenshots or rendered preview
+- tests
+
+## Checklist
+
+- [ ] I kept reusable templates de-localized.
+- [ ] I did not add secrets, credentials, or sensitive personal data.
+- [ ] I updated related docs or examples if the behavior changed.
+- [ ] I noted any migration or compatibility impact if this is breaking.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,73 @@
+# Code of Conduct
+
+## Our goal
+
+This repository exists to share reusable knowledge-base workflows, documentation patterns, and skill bundles. We want the project to remain welcoming, practical, and safe for contributors and users.
+
+## Expected behavior
+
+Examples of behavior that contribute to a healthy community include:
+- being respectful and constructive in technical discussion
+- assuming good intent while still giving clear review feedback
+- focusing criticism on ideas, wording, structure, or implementation rather than people
+- being careful with privacy, consent, and sensitive-data handling
+- helping keep reusable templates de-localized and generally applicable
+
+## Unacceptable behavior
+
+Examples of unacceptable behavior include:
+- harassment, intimidation, or personal attacks
+- discriminatory or hateful language
+- doxxing or sharing private information without permission
+- posting secrets, credentials, or sensitive user data
+- deliberately misleading bug reports, security reports, or review comments
+- repeated low-signal disruption after reasonable moderator requests
+
+## Scope
+
+This Code of Conduct applies to:
+- issues
+- pull requests
+- review comments
+- discussions
+- other project-linked community spaces managed by the maintainers
+
+## Maintainer responsibilities
+
+Maintainers may:
+- edit, hide, lock, or remove content that violates this policy
+- ask contributors to change tone or behavior
+- pause or reject participation when conduct repeatedly harms the project
+
+## Reporting
+
+If you experience or witness behavior that violates this Code of Conduct, please contact the maintainers privately through GitHub contact channels rather than escalating publicly when possible.
+
+When reporting, include:
+- what happened
+- where it happened
+- links or screenshots if relevant
+- whether there is any immediate safety or privacy concern
+
+## Enforcement principles
+
+Maintainers will try to respond proportionally, considering:
+- severity
+- repetition
+- privacy and safety impact
+- whether the issue appears accidental or intentional
+
+Possible responses include:
+- a private warning
+- a request to edit or remove content
+- temporary moderation actions
+- removal from project spaces in serious or repeated cases
+
+## Project-specific note
+
+Because this repository discusses knowledge management, collaboration profiles, and shared-project coordination, contributors should be especially careful with:
+- consent
+- visibility boundaries
+- sensitive personal information
+- third-party privacy
+- overclaiming automation or data handling capabilities

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,52 @@
+# Security Policy
+
+## Supported versions
+
+This repository is maintained as a reusable documentation-and-skill package. Security fixes are applied to the current development line and the latest published release.
+
+| Version | Supported |
+|---|---|
+| `main` | ✅ |
+| Latest release | ✅ |
+| Older releases | ❌ |
+
+## Reporting a vulnerability
+
+If you believe you have found a security issue, please **do not open a public issue with full exploit details**.
+
+Preferred reporting path:
+1. Use **GitHub private vulnerability reporting** / a private security advisory if it is available for this repository.
+2. If private reporting is not available, contact the maintainers through their GitHub profiles before public disclosure.
+3. Use a public issue only for **non-sensitive hardening questions** or when the report does not expose a real exploit path.
+
+When reporting, please include:
+- a short summary of the issue
+- the affected file(s), script(s), or workflow(s)
+- reproduction steps
+- impact and scope
+- any suggested mitigation if you already have one
+
+## What to expect
+
+The maintainers will try to:
+- acknowledge the report in a reasonable time
+- assess severity and scope
+- decide whether a fix belongs on `main`, the latest release, or both
+- coordinate disclosure once a fix or mitigation is ready
+
+## Scope notes
+
+This repository mainly contains:
+- markdown documentation
+- reusable templates
+- skill metadata and helper scripts
+
+Typical security-relevant areas include:
+- shell scripts in `skills/**/scripts/`
+- template wording that could encourage unsafe behavior
+- instructions that cause users to expose private data or secrets
+- automation or coordination flows that mishandle sensitive information
+
+## Sensitive data rule
+
+Do not include API keys, tokens, passwords, cookies, or private user data in public issues, pull requests, or example files.


### PR DESCRIPTION
## Summary
- add missing community governance and contribution-support documents
- establish a basic security policy, code of conduct, issue templates, and PR template
- improve repository readiness for open-source collaboration without changing product behavior

## Added
- `SECURITY.md`
- `CODE_OF_CONDUCT.md`
- `.github/ISSUE_TEMPLATE/config.yml`
- `.github/ISSUE_TEMPLATE/bug_report.yml`
- `.github/ISSUE_TEMPLATE/feature_request.yml`
- `.github/PULL_REQUEST_TEMPLATE.md`

## Notes
- this PR focuses on community / governance docs only
- README badge or media enhancements can be handled separately if desired
