### PR TITLE
Add HTML homepage CTA to READMEs

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -10,6 +10,16 @@
 > An **8-skill knowledge-base package** for markdown / wiki / Obsidian-style vaults.  
 > The goal is not to record more logs, but to keep a vault **navigable, role-stable, maintainable, collaboration-friendly, and auditable**.
 
+<p align="center">
+  <a href="https://zouxy111.github.io/wiki-knowledgebase-share-kit/"><img src="https://img.shields.io/badge/Open-HTML_Homepage-4ab9ff?style=for-the-badge" alt="Open HTML Homepage" /></a>
+  <a href="./START-HERE.md"><img src="https://img.shields.io/badge/Read-START--HERE-0f172a?style=for-the-badge" alt="Read START-HERE" /></a>
+  <a href="https://github.com/zouxy111/wiki-knowledgebase-share-kit/releases"><img src="https://img.shields.io/badge/Browse-Releases-0ea5a4?style=for-the-badge" alt="Browse Releases" /></a>
+</p>
+
+[![HTML homepage preview](./docs/assets/social-preview.png)](https://zouxy111.github.io/wiki-knowledgebase-share-kit/)
+
+> If you want the more product-like HTML landing page, open the **HTML Homepage** above; the repository README continues to handle installation, routing, and method documentation.
+
 ---
 
 ## 30-second overview

--- a/README.md
+++ b/README.md
@@ -10,6 +10,16 @@
 > 一套面向 markdown / wiki / Obsidian-style vault 的 **8-skill 知识库维护包**。  
 > 目标不是堆更多日志，而是把知识库收敛成：**入口清楚、页面角色稳定、长期可维护、对协作友好、可审计**。
 
+<p align="center">
+  <a href="https://zouxy111.github.io/wiki-knowledgebase-share-kit/"><img src="https://img.shields.io/badge/Open-HTML_Homepage-4ab9ff?style=for-the-badge" alt="Open HTML Homepage" /></a>
+  <a href="./START-HERE.md"><img src="https://img.shields.io/badge/Read-START--HERE-0f172a?style=for-the-badge" alt="Read START-HERE" /></a>
+  <a href="https://github.com/zouxy111/wiki-knowledgebase-share-kit/releases"><img src="https://img.shields.io/badge/Browse-Releases-0ea5a4?style=for-the-badge" alt="Browse Releases" /></a>
+</p>
+
+[![HTML homepage preview](./docs/assets/social-preview.png)](https://zouxy111.github.io/wiki-knowledgebase-share-kit/)
+
+> 想看更像产品首页的 HTML 界面，请直接打开上面的 **HTML Homepage**；仓库 README 继续承担安装、分流和方法说明。
+
 ---
 
 ## 30 秒看懂

--- a/docs/index.html
+++ b/docs/index.html
@@ -350,8 +350,10 @@
       top: 74px;
       width: min(1180px, 90vw);
       height: min(46vh, 390px);
-      opacity: .42;
-      filter: drop-shadow(0 0 28px rgba(100, 255, 177, .12));
+      opacity: .84;
+      mix-blend-mode: normal;
+      filter: drop-shadow(0 0 24px rgba(100, 255, 177, .16));
+      mask-image: linear-gradient(180deg, rgba(0,0,0,.98), rgba(0,0,0,.95) 74%, rgba(0,0,0,.46));
     }
 
     .ambient-illustration .hud-arc,
@@ -375,19 +377,19 @@
 
     .ambient-illustration .brain-lobe {
       stroke: url(#brainShellGlow);
-      stroke-width: 3.4;
-      fill: rgba(42, 124, 255, .05);
+      stroke-width: 4;
+      fill: rgba(42, 124, 255, .09);
     }
 
     .ambient-illustration .brain-fold {
-      stroke: rgba(124, 221, 255, .28);
-      stroke-width: 2.1;
+      stroke: rgba(124, 221, 255, .42);
+      stroke-width: 2.4;
     }
 
     .ambient-illustration .data-stream {
       fill: none;
       stroke: url(#streamGlow);
-      stroke-width: 3.2;
+      stroke-width: 4.1;
       stroke-linecap: round;
       stroke-linejoin: round;
       stroke-dasharray: 10 16;
@@ -396,7 +398,7 @@
 
     .ambient-illustration .data-stream.soft {
       stroke: rgba(110, 220, 255, .48);
-      stroke-width: 2;
+      stroke-width: 2.6;
       stroke-dasharray: 5 12;
       animation-duration: 7.8s;
     }
@@ -443,6 +445,29 @@
     .ambient-illustration .drive-led:nth-of-type(2) { animation-delay: .5s; fill: rgba(110, 220, 255, .92); }
     .ambient-illustration .drive-led:nth-of-type(3) { animation-delay: 1s; fill: rgba(255, 233, 110, .88); }
 
+    .ambient-illustration .drive-ring {
+      fill: none;
+      stroke: rgba(180, 236, 255, .26);
+      stroke-width: 2;
+      transform-origin: 600px 370px;
+      animation: platterSpin 9s linear infinite;
+    }
+
+    .ambient-illustration .drive-scan {
+      fill: none;
+      stroke: rgba(110, 220, 255, .42);
+      stroke-width: 2.4;
+      stroke-linecap: round;
+      transform-origin: 600px 370px;
+      animation: scanSweep 4.2s ease-in-out infinite;
+    }
+
+    .ambient-illustration .data-packet {
+      fill: #d7ffff;
+      opacity: .95;
+      filter: drop-shadow(0 0 12px rgba(120, 255, 219, .86));
+    }
+
     .clone-head {
       display: flex;
       align-items: center;
@@ -478,10 +503,11 @@
     .panel {
       border-radius: var(--radius-xl);
       background:
-        linear-gradient(180deg, rgba(255,255,255,.035), rgba(255,255,255,.015)),
-        var(--panel);
+        linear-gradient(180deg, rgba(255,255,255,.012), rgba(255,255,255,.004)),
+        rgba(8, 18, 31, .05);
       box-shadow: var(--shadow);
       overflow: hidden;
+      backdrop-filter: blur(6px) saturate(1.04);
     }
 
     .hero-copy,
@@ -500,11 +526,11 @@
       flex-direction: column;
       min-height: 100%;
       background:
-        linear-gradient(180deg, rgba(9, 18, 34, .62), rgba(9, 18, 34, .34)),
-        radial-gradient(circle at 68% 24%, rgba(105,211,255,.08), transparent 34%),
-        rgba(8, 18, 31, .22);
-      backdrop-filter: blur(14px) saturate(1.08);
-      border-color: rgba(255,255,255,.08);
+        linear-gradient(180deg, rgba(9, 18, 34, .16), rgba(9, 18, 34, .03)),
+        radial-gradient(circle at 68% 24%, rgba(105,211,255,.12), transparent 36%),
+        rgba(8, 18, 31, .02);
+      backdrop-filter: blur(4px) saturate(1.06);
+      border-color: rgba(255,255,255,.05);
     }
 
     .hero-copy::before {
@@ -512,13 +538,13 @@
       position: absolute;
       inset: 0;
       background:
-        linear-gradient(180deg, rgba(255,255,255,.02), rgba(255,255,255,0)),
-        radial-gradient(circle at 50% 100%, rgba(105,211,255,.08), transparent 46%),
-        repeating-linear-gradient(0deg, rgba(255,255,255,.02) 0 1px, transparent 1px 14px),
-        repeating-linear-gradient(90deg, rgba(255,255,255,.012) 0 1px, transparent 1px 18px);
-      opacity: .46;
+        linear-gradient(180deg, rgba(255,255,255,.018), rgba(255,255,255,0)),
+        radial-gradient(circle at 50% 100%, rgba(105,211,255,.09), transparent 46%),
+        repeating-linear-gradient(0deg, rgba(255,255,255,.015) 0 1px, transparent 1px 14px),
+        repeating-linear-gradient(90deg, rgba(255,255,255,.010) 0 1px, transparent 1px 18px);
+      opacity: .14;
       pointer-events: none;
-      mask-image: linear-gradient(180deg, rgba(0,0,0,.78), rgba(0,0,0,.92) 65%, rgba(0,0,0,.38));
+      mask-image: linear-gradient(180deg, rgba(0,0,0,.62), rgba(0,0,0,.82) 58%, rgba(0,0,0,.14));
     }
 
     .hero-copy::after {
@@ -532,6 +558,11 @@
       z-index: -1;
       filter: blur(8px);
       animation: drift 9s ease-in-out infinite alternate;
+    }
+
+    .hero-copy > * {
+      position: relative;
+      z-index: 1;
     }
 
     .eyebrow {
@@ -563,9 +594,9 @@
     }
 
     html[lang="zh-CN"] h1 {
-      font-size: clamp(34px, 4.9vw, 58px);
-      line-height: 1.03;
-      max-width: 11.2ch;
+      font-size: clamp(28px, 4vw, 50px);
+      line-height: 1.06;
+      max-width: 12.8ch;
       letter-spacing: -.04em;
     }
 
@@ -688,10 +719,10 @@
       gap: 16px;
       background:
         radial-gradient(circle at top right, rgba(105,211,255,.12), transparent 38%),
-        linear-gradient(180deg, rgba(9, 18, 34, .72), rgba(9, 18, 34, .42)),
-        rgba(8, 18, 31, .22);
-      backdrop-filter: blur(16px) saturate(1.06);
-      border-color: rgba(255,255,255,.08);
+        linear-gradient(180deg, rgba(9, 18, 34, .14), rgba(9, 18, 34, .04)),
+        rgba(8, 18, 31, .02);
+      backdrop-filter: blur(5px) saturate(1.04);
+      border-color: rgba(255,255,255,.05);
     }
 
     .stats-grid,
@@ -712,7 +743,8 @@
     .switcher-shell {
       border-radius: var(--radius-lg);
       padding: 18px;
-      background: rgba(255,255,255,.03);
+      background: rgba(14, 26, 43, .32);
+      backdrop-filter: blur(10px);
     }
 
     .stat-card strong {
@@ -1197,6 +1229,16 @@
       to { stroke-dashoffset: -110; opacity: .32; }
     }
 
+    @keyframes platterSpin {
+      from { transform: rotate(0deg); opacity: .22; }
+      to { transform: rotate(360deg); opacity: .32; }
+    }
+
+    @keyframes scanSweep {
+      0%, 100% { transform: rotate(-18deg); opacity: .12; }
+      50% { transform: rotate(22deg); opacity: .52; }
+    }
+
     @media (max-width: 1100px) {
       .grid-4 { grid-template-columns: repeat(2, minmax(0, 1fr)); }
       .flow { grid-template-columns: repeat(3, minmax(0, 1fr)); }
@@ -1312,16 +1354,16 @@
         <path class="brain-fold" d="M816 96C848 130 850 188 822 234M756 72C776 120 776 192 744 250M680 68C694 120 692 190 670 248M596 82C596 132 602 198 628 250" />
         <path class="brain-fold" d="M336 184C390 170 446 184 488 214M712 214C754 184 810 170 864 184M382 286C432 260 500 258 556 282M646 282C702 258 770 260 820 286" />
 
-        <path class="data-stream" d="M596 296V356" />
-        <path class="data-stream" d="M620 290V360" />
-        <path class="data-stream soft" d="M572 288V354" />
-        <path class="data-stream soft" d="M644 286V354" />
-        <path class="data-stream" d="M520 214C548 214 562 236 582 250V338" />
-        <path class="data-stream" d="M464 184C516 184 540 210 562 236" />
-        <path class="data-stream soft" d="M408 150C476 150 520 176 556 218" />
-        <path class="data-stream" d="M672 214C644 214 630 236 610 250V338" />
-        <path class="data-stream" d="M728 184C676 184 652 210 630 236" />
-        <path class="data-stream soft" d="M784 150C716 150 672 176 636 218" />
+        <path id="stream-center-a" class="data-stream" d="M596 296V356" />
+        <path id="stream-center-b" class="data-stream" d="M620 290V360" />
+        <path id="stream-center-c" class="data-stream soft" d="M572 288V354" />
+        <path id="stream-center-d" class="data-stream soft" d="M644 286V354" />
+        <path id="stream-left-a" class="data-stream" d="M520 214C548 214 562 236 582 250V338" />
+        <path id="stream-left-b" class="data-stream" d="M464 184C516 184 540 210 562 236" />
+        <path id="stream-left-c" class="data-stream soft" d="M408 150C476 150 520 176 556 218" />
+        <path id="stream-right-a" class="data-stream" d="M672 214C644 214 630 236 610 250V338" />
+        <path id="stream-right-b" class="data-stream" d="M728 184C676 184 652 210 630 236" />
+        <path id="stream-right-c" class="data-stream soft" d="M784 150C716 150 672 176 636 218" />
 
         <circle class="neuron-node" cx="408" cy="150" r="5" />
         <circle class="neuron-node" cx="464" cy="184" r="4.5" />
@@ -1336,6 +1378,8 @@
         <path class="drive-top" d="M368 304H830L804 276H394L368 304Z" />
         <path class="drive-plate" d="M426 320H770C786 320 800 334 800 350V394C800 410 786 424 770 424H426C410 424 396 410 396 394V350C396 334 410 320 426 320Z" />
         <path class="drive-plate" d="M516 334C548 320 650 320 684 334C706 344 714 364 708 386C700 410 668 424 634 426H564C520 424 484 406 482 378C480 360 492 342 516 334Z" />
+        <ellipse class="drive-ring" cx="596" cy="372" rx="92" ry="34" />
+        <path class="drive-scan" d="M520 370C552 346 638 344 690 366" />
         <path class="drive-port" d="M420 370H470M484 370H516M540 370H560M640 388H716M730 388H764M782 388H794" />
         <path class="drive-port" d="M416 402H510V420H416Z" />
         <path class="drive-port" d="M648 404H712V420H648Z" />
@@ -1344,6 +1388,37 @@
         <circle class="drive-led" cx="442" cy="350" r="5" />
         <circle class="drive-led" cx="468" cy="350" r="5" />
         <circle class="drive-led" cx="494" cy="350" r="5" />
+
+        <circle class="data-packet" r="4">
+          <animateMotion dur="3.6s" repeatCount="indefinite" rotate="auto">
+            <mpath href="#stream-left-c" />
+          </animateMotion>
+        </circle>
+        <circle class="data-packet" r="3.6">
+          <animateMotion dur="2.8s" begin=".6s" repeatCount="indefinite" rotate="auto">
+            <mpath href="#stream-left-a" />
+          </animateMotion>
+        </circle>
+        <circle class="data-packet" r="3.8">
+          <animateMotion dur="3.2s" begin="1.2s" repeatCount="indefinite" rotate="auto">
+            <mpath href="#stream-right-c" />
+          </animateMotion>
+        </circle>
+        <circle class="data-packet" r="3.2">
+          <animateMotion dur="2.6s" begin=".4s" repeatCount="indefinite" rotate="auto">
+            <mpath href="#stream-right-a" />
+          </animateMotion>
+        </circle>
+        <circle class="data-packet" r="3.4">
+          <animateMotion dur="2.2s" begin=".2s" repeatCount="indefinite" rotate="auto">
+            <mpath href="#stream-center-a" />
+          </animateMotion>
+        </circle>
+        <circle class="data-packet" r="3.4">
+          <animateMotion dur="2.4s" begin=".8s" repeatCount="indefinite" rotate="auto">
+            <mpath href="#stream-center-b" />
+          </animateMotion>
+        </circle>
       </svg>
     </div>
   </div>
@@ -1963,7 +2038,7 @@
         navStart: "快速开始",
         navRelease: "最新版本",
         heroEyebrow: "结构化知识，而不是笔记蔓延",
-        heroTitle: "把 <span>markdown vault</span><br>变成真正可用的<br>知识库。",
+        heroTitle: "<span>把 markdown vault</span><br>变成真正可用的<br>知识库。",
         heroLede: "这是一个可复用的开源工作包，包含 8 个可安装 skills 和 7 条协同工作流。它帮助个人和团队让 vault 保持可导航、角色稳定、可维护、便于协作、可审计，而不是继续漂成零散笔记和过程流水账。",
         heroCtaRepo: "获取仓库",
         heroCtaStart: "阅读 START-HERE",

--- a/docs/index.html
+++ b/docs/index.html
@@ -8,42 +8,40 @@
   <style>
     :root {
       --bg: #07111f;
-      --bg-2: #09192d;
-      --panel: rgba(10, 21, 38, 0.84);
-      --panel-strong: rgba(12, 26, 46, 0.92);
+      --bg-2: #0a1628;
+      --panel: rgba(11, 23, 40, 0.9);
+      --panel-2: rgba(13, 28, 49, 0.95);
       --line: rgba(255,255,255,.10);
       --line-strong: rgba(255,255,255,.18);
-      --text: #ecf4ff;
-      --muted: #9db1ca;
+      --text: #edf5ff;
+      --muted: #9eb1ca;
       --accent: #69d3ff;
       --accent-2: #8af2d0;
-      --accent-3: #9aa8ff;
-      --glow: rgba(105, 211, 255, 0.22);
-      --shadow: 0 24px 80px rgba(0,0,0,.30);
+      --accent-3: #96a6ff;
+      --shadow: 0 24px 70px rgba(0,0,0,.30);
       font-family: Geist, Outfit, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
     }
 
     * { box-sizing: border-box; }
-
     html { scroll-behavior: smooth; }
 
     body {
       margin: 0;
       color: var(--text);
-      line-height: 1.6;
+      line-height: 1.65;
+      overflow-x: hidden;
       background:
-        radial-gradient(circle at 10% 10%, rgba(105, 211, 255, 0.18), transparent 24%),
-        radial-gradient(circle at 88% 18%, rgba(154, 168, 255, 0.18), transparent 26%),
-        radial-gradient(circle at 50% 100%, rgba(138, 242, 208, 0.10), transparent 28%),
-        linear-gradient(180deg, #081220 0%, #07111f 42%, #050b14 100%);
+        radial-gradient(circle at 12% 12%, rgba(105, 211, 255, 0.18), transparent 24%),
+        radial-gradient(circle at 88% 18%, rgba(150, 166, 255, 0.16), transparent 26%),
+        linear-gradient(180deg, #08121f 0%, #07111f 45%, #050b14 100%);
     }
 
     a { color: inherit; text-decoration: none; }
-    img { max-width: 100%; display: block; }
-    code { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
+    img { display: block; max-width: 100%; }
+    code, pre { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
 
     .shell {
-      width: min(1240px, calc(100vw - 40px));
+      width: min(1200px, calc(100vw - 32px));
       margin: 0 auto;
     }
 
@@ -51,8 +49,8 @@
       position: sticky;
       top: 0;
       z-index: 30;
-      backdrop-filter: blur(16px);
-      background: rgba(7, 17, 31, 0.72);
+      backdrop-filter: blur(14px);
+      background: rgba(7, 17, 31, 0.74);
       border-bottom: 1px solid rgba(255,255,255,.06);
     }
 
@@ -64,26 +62,23 @@
       padding: 16px 0;
     }
 
-    .brand-wrap {
+    .brand {
       display: flex;
       align-items: center;
-      gap: 14px;
+      gap: 12px;
     }
 
     .brand-mark {
       width: 42px;
       height: 42px;
       border-radius: 14px;
-      border: 1px solid rgba(255,255,255,.12);
-      background:
-        linear-gradient(135deg, rgba(105, 211, 255, .22), rgba(138, 242, 208, .10)),
-        rgba(255,255,255,.03);
       display: grid;
       place-items: center;
       font-weight: 800;
-      letter-spacing: -.04em;
-      color: #dff6ff;
-      box-shadow: inset 0 1px 0 rgba(255,255,255,.06);
+      letter-spacing: -.05em;
+      background: linear-gradient(135deg, rgba(105,211,255,.24), rgba(138,242,208,.12));
+      border: 1px solid rgba(255,255,255,.12);
+      color: #dbf6ff;
     }
 
     .brand-copy strong {
@@ -94,21 +89,21 @@
 
     .brand-copy span {
       display: block;
-      font-size: 12px;
       color: var(--muted);
-      letter-spacing: .06em;
+      font-size: 12px;
+      letter-spacing: .08em;
       text-transform: uppercase;
     }
 
     .nav-links {
       display: flex;
       flex-wrap: wrap;
-      gap: 12px;
+      gap: 10px;
     }
 
     .pill,
     .btn,
-    .tag {
+    .chip {
       border: 1px solid var(--line);
       border-radius: 999px;
     }
@@ -119,23 +114,25 @@
       background: rgba(255,255,255,.02);
     }
 
+    .pill:hover,
+    .btn.secondary:hover {
+      border-color: var(--line-strong);
+      background: rgba(255,255,255,.05);
+    }
+
     .hero {
-      position: relative;
-      overflow: hidden;
-      padding: 52px 0 34px;
+      padding: 52px 0 26px;
     }
 
     .hero-grid {
       display: grid;
-      grid-template-columns: minmax(0, 1.2fr) minmax(360px, .8fr);
+      grid-template-columns: minmax(0, 1.15fr) minmax(0, .85fr);
       gap: 22px;
-      align-items: stretch;
     }
 
     .panel {
-      position: relative;
       border: 1px solid var(--line);
-      border-radius: 30px;
+      border-radius: 28px;
       background:
         linear-gradient(180deg, rgba(255,255,255,.035), rgba(255,255,255,.015)),
         var(--panel);
@@ -143,34 +140,24 @@
       overflow: hidden;
     }
 
-    .panel::before {
-      content: "";
-      position: absolute;
-      inset: 0;
-      background: linear-gradient(180deg, rgba(255,255,255,.06), transparent 20%);
-      pointer-events: none;
-    }
-
     .hero-copy,
     .hero-side,
     .section-card,
     .flow-step,
-    .scenario-card,
-    .role-card,
-    .cta-card,
+    .mini-card,
     .footer-card {
-      padding: 30px;
+      padding: 28px;
     }
 
     .eyebrow {
       display: inline-flex;
       align-items: center;
       gap: 10px;
-      margin-bottom: 20px;
       color: var(--accent);
       text-transform: uppercase;
       letter-spacing: .22em;
       font-size: 12px;
+      margin-bottom: 18px;
     }
 
     .eyebrow::before {
@@ -181,35 +168,94 @@
     }
 
     h1 {
-      margin: 0 0 18px;
-      font-size: clamp(44px, 6vw, 82px);
-      line-height: .94;
+      margin: 0 0 16px;
+      font-size: clamp(42px, 6vw, 76px);
+      line-height: .95;
       letter-spacing: -.05em;
       max-width: 10ch;
     }
 
     h2 {
-      margin: 0 0 14px;
-      font-size: clamp(28px, 4vw, 42px);
+      margin: 0 0 12px;
+      font-size: clamp(28px, 4vw, 40px);
       letter-spacing: -.03em;
     }
 
     h3 {
       margin: 0 0 10px;
-      font-size: 22px;
+      font-size: 21px;
       letter-spacing: -.02em;
+    }
+
+    .lede,
+    .sub,
+    .muted,
+    .card-copy,
+    .flow-step p,
+    .mini-card p,
+    .hero-note {
+      color: var(--muted);
     }
 
     .lede {
       margin: 0;
       max-width: 62ch;
       font-size: 18px;
-      color: var(--muted);
     }
 
-    .cta-row,
-    .tag-row,
-    .stats,
+    .cta-row {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 12px;
+      margin: 26px 0 18px;
+    }
+
+    .btn {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      gap: 10px;
+      padding: 14px 18px;
+      font-weight: 700;
+      background: rgba(255,255,255,.03);
+    }
+
+    .btn.primary {
+      color: #07111f;
+      border-color: transparent;
+      background: linear-gradient(135deg, var(--accent), #84a7ff 52%, var(--accent-2));
+      box-shadow: 0 14px 36px rgba(105,211,255,.22);
+    }
+
+    .chip-row {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 10px;
+      margin-top: 12px;
+    }
+
+    .chip {
+      padding: 8px 12px;
+      color: var(--muted);
+      font-size: 13px;
+      background: rgba(255,255,255,.03);
+    }
+
+    .hero-note {
+      margin-top: 12px;
+      font-size: 14px;
+    }
+
+    .hero-side {
+      display: grid;
+      gap: 16px;
+      background:
+        radial-gradient(circle at top right, rgba(105,211,255,.15), transparent 38%),
+        linear-gradient(180deg, rgba(255,255,255,.03), rgba(255,255,255,.015)),
+        var(--panel-2);
+    }
+
+    .stats-grid,
     .grid-2,
     .grid-3,
     .grid-4,
@@ -218,101 +264,46 @@
       gap: 18px;
     }
 
-    .cta-row {
-      display: flex;
-      flex-wrap: wrap;
-      gap: 14px;
-      margin: 26px 0 22px;
+    .stats-grid {
+      grid-template-columns: repeat(2, minmax(0,1fr));
     }
 
-    .btn {
-      display: inline-flex;
-      align-items: center;
-      justify-content: center;
-      gap: 10px;
-      padding: 15px 18px;
-      font-weight: 700;
+    .stat-card,
+    .clone-card,
+    .preview-card {
+      border: 1px solid var(--line);
+      border-radius: 22px;
       background: rgba(255,255,255,.03);
+      padding: 18px;
     }
 
-    .btn.primary {
-      color: #07111f;
-      background: linear-gradient(135deg, var(--accent), #80a8ff 52%, var(--accent-2));
-      border-color: transparent;
-      box-shadow: 0 16px 40px rgba(105, 211, 255, .24);
+    .stat-card strong {
+      display: block;
+      margin: 6px 0 8px;
+      font-size: clamp(34px, 5vw, 52px);
+      line-height: .95;
+      letter-spacing: -.05em;
     }
 
-    .btn.secondary:hover,
-    .pill:hover {
-      border-color: var(--line-strong);
-      background: rgba(255,255,255,.05);
-    }
-
-    .tag-row {
-      grid-template-columns: repeat(5, minmax(0, max-content));
-      align-items: start;
-      gap: 10px;
-    }
-
-    .tag {
-      display: inline-flex;
-      padding: 8px 12px;
-      color: var(--muted);
-      background: rgba(255,255,255,.03);
+    .clone-card pre {
+      margin: 12px 0 0;
+      padding: 14px;
+      border-radius: 16px;
+      border: 1px solid rgba(255,255,255,.08);
+      background: rgba(4, 10, 18, .75);
+      color: #dff6ff;
+      overflow-x: auto;
+      white-space: pre-wrap;
+      overflow-wrap: anywhere;
+      word-break: break-word;
       font-size: 13px;
     }
 
-    .micro-note {
-      margin-top: 8px;
-      color: var(--muted);
-      font-size: 14px;
-    }
-
-    .hero-side {
-      display: flex;
-      flex-direction: column;
-      gap: 18px;
-      background:
-        radial-gradient(circle at top right, rgba(105, 211, 255, .14), transparent 38%),
-        linear-gradient(180deg, rgba(255,255,255,.03), rgba(255,255,255,.015)),
-        var(--panel-strong);
-    }
-
-    .metric-block {
-      display: grid;
-      grid-template-columns: repeat(2, minmax(0, 1fr));
-      gap: 14px;
-    }
-
-    .metric-card {
-      padding: 16px;
-      border: 1px solid var(--line);
+    .preview-shell {
       border-radius: 22px;
-      background: rgba(255,255,255,.025);
-    }
-
-    .metric-card strong {
-      display: block;
-      font-size: clamp(34px, 5vw, 54px);
-      letter-spacing: -.05em;
-      line-height: .95;
-      margin-bottom: 8px;
-    }
-
-    .metric-card span,
-    .sub,
-    .card-copy,
-    .flow-step p,
-    .muted {
-      color: var(--muted);
-    }
-
-    .preview-frame {
-      border: 1px solid var(--line);
-      border-radius: 24px;
       overflow: hidden;
-      background: rgba(255,255,255,.03);
-      box-shadow: inset 0 1px 0 rgba(255,255,255,.05);
+      border: 1px solid var(--line);
+      background: rgba(255,255,255,.025);
     }
 
     .preview-topbar {
@@ -324,49 +315,39 @@
       background: rgba(255,255,255,.03);
     }
 
-    .dot {
-      width: 10px;
-      height: 10px;
-      border-radius: 999px;
-      background: rgba(255,255,255,.22);
-    }
-
+    .dot { width: 10px; height: 10px; border-radius: 999px; }
     .dot:nth-child(1) { background: #ff6b6b; }
     .dot:nth-child(2) { background: #ffd166; }
     .dot:nth-child(3) { background: #7ae582; }
 
-    .preview-meta {
+    .preview-topbar span:last-child {
       margin-left: auto;
-      font-size: 12px;
       color: var(--muted);
+      font-size: 12px;
       text-transform: uppercase;
-      letter-spacing: .14em;
+      letter-spacing: .16em;
     }
 
-    .preview-frame img {
+    .preview-shell img {
       width: 100%;
       height: auto;
       object-fit: cover;
     }
 
     .section {
-      padding: 24px 0 26px;
+      padding: 28px 0;
     }
 
     .section-head {
       display: flex;
-      flex-wrap: wrap;
-      align-items: end;
       justify-content: space-between;
-      gap: 18px;
+      align-items: end;
+      flex-wrap: wrap;
+      gap: 16px;
       margin-bottom: 18px;
     }
 
-    .sub {
-      max-width: 68ch;
-      margin: 0;
-      font-size: 16px;
-    }
+    .sub { max-width: 68ch; margin: 0; }
 
     .grid-2 { grid-template-columns: repeat(2, minmax(0,1fr)); }
     .grid-3 { grid-template-columns: repeat(3, minmax(0,1fr)); }
@@ -374,33 +355,12 @@
     .flow { grid-template-columns: repeat(5, minmax(0,1fr)); }
 
     .section-card,
-    .scenario-card,
-    .role-card,
     .flow-step,
-    .cta-card,
+    .mini-card,
     .footer-card {
       border: 1px solid var(--line);
-      border-radius: 28px;
+      border-radius: 26px;
       background: rgba(255,255,255,.022);
-      min-height: 100%;
-    }
-
-    .section-card p,
-    .scenario-card p,
-    .role-card p,
-    .role-card ul,
-    .section-card ul,
-    .scenario-card ul {
-      margin: 0;
-      color: var(--muted);
-    }
-
-    .section-card ul,
-    .scenario-card ul {
-      padding-left: 18px;
-      display: grid;
-      gap: 8px;
-      margin-top: 12px;
     }
 
     .role-label {
@@ -415,9 +375,18 @@
       letter-spacing: .16em;
     }
 
+    .section-card ul,
+    .mini-card ul {
+      margin: 12px 0 0;
+      padding-left: 18px;
+      color: var(--muted);
+      display: grid;
+      gap: 8px;
+    }
+
     .compare-shell {
       border: 1px solid var(--line);
-      border-radius: 28px;
+      border-radius: 26px;
       overflow: hidden;
       background: rgba(255,255,255,.02);
     }
@@ -431,39 +400,30 @@
     .compare-shell td {
       padding: 18px;
       border-bottom: 1px solid var(--line);
-      vertical-align: top;
       text-align: left;
+      vertical-align: top;
     }
 
     .compare-shell th {
-      font-size: 14px;
-      color: #dff6ff;
       background: rgba(255,255,255,.03);
-    }
-
-    .flow-step {
-      position: relative;
-      overflow: hidden;
+      font-size: 14px;
     }
 
     .flow-step small {
       display: block;
       margin-bottom: 10px;
       color: var(--accent);
-      font-size: 12px;
-      letter-spacing: .22em;
       text-transform: uppercase;
+      letter-spacing: .22em;
+      font-size: 12px;
     }
 
-    .flow-step p {
-      margin: 10px 0 0;
-    }
+    .flow-step p { margin: 10px 0 0; }
 
     .cta-band {
       display: grid;
-      grid-template-columns: 1.2fr .8fr;
+      grid-template-columns: minmax(0,1.15fr) minmax(0,.85fr);
       gap: 20px;
-      align-items: stretch;
     }
 
     .cta-card.primary {
@@ -472,17 +432,15 @@
         linear-gradient(135deg, rgba(255,255,255,.05), rgba(255,255,255,.015));
     }
 
-    .cta-card .cta-row {
-      margin-bottom: 0;
-    }
+    .footer-wrap { padding: 8px 0 42px; }
 
     .footer-card {
       display: flex;
-      flex-wrap: wrap;
       justify-content: space-between;
       align-items: center;
+      flex-wrap: wrap;
       gap: 18px;
-      margin: 0 0 42px;
+      padding: 24px 28px;
     }
 
     .footer-links {
@@ -492,12 +450,11 @@
       color: var(--muted);
     }
 
-    @media (max-width: 1180px) {
+    @media (max-width: 1160px) {
       .hero-grid,
       .cta-band,
       .grid-4,
       .flow { grid-template-columns: 1fr 1fr; }
-      .tag-row { grid-template-columns: repeat(3, max-content); }
     }
 
     @media (max-width: 920px) {
@@ -506,34 +463,31 @@
       .grid-4,
       .grid-3,
       .grid-2,
-      .flow { grid-template-columns: 1fr; }
+      .flow,
+      .stats-grid { grid-template-columns: 1fr; }
+      .nav { flex-direction: column; align-items: flex-start; }
       .hero-copy,
       .hero-side,
       .section-card,
       .flow-step,
-      .scenario-card,
-      .role-card,
-      .cta-card,
+      .mini-card,
       .footer-card { padding: 24px; }
-      .nav { align-items: flex-start; flex-direction: column; }
-      .tag-row { grid-template-columns: repeat(2, max-content); }
     }
 
     @media (max-width: 620px) {
-      .shell { width: min(100vw - 24px, 1240px); }
-      .pill,
-      .btn { width: 100%; justify-content: center; }
+      .shell { width: min(100vw - 24px, 1200px); }
       .nav-links,
       .cta-row { width: 100%; }
-      .metric-block { grid-template-columns: 1fr; }
-      .tag-row { grid-template-columns: 1fr 1fr; }
+      .pill,
+      .btn { width: 100%; justify-content: center; }
+      h1 { max-width: none; }
     }
   </style>
 </head>
 <body>
   <header class="site-header">
     <div class="shell nav">
-      <div class="brand-wrap">
+      <div class="brand">
         <div class="brand-mark">WK</div>
         <div class="brand-copy">
           <strong>Wiki Knowledge Base Share Kit</strong>
@@ -541,7 +495,7 @@
         </div>
       </div>
       <div class="nav-links">
-        <a class="pill" href="https://github.com/zouxy111/wiki-knowledgebase-share-kit">GitHub</a>
+        <a class="pill" href="https://github.com/zouxy111/wiki-knowledgebase-share-kit">GitHub repo</a>
         <a class="pill" href="https://github.com/zouxy111/wiki-knowledgebase-share-kit/blob/main/START-HERE.md">Start Here</a>
         <a class="pill" href="https://github.com/zouxy111/wiki-knowledgebase-share-kit/releases/latest">Latest release</a>
       </div>
@@ -557,45 +511,52 @@
           <p class="lede">
             A reusable open-source package with 8 installable skills and 7 coordinated workflow tracks.
             It helps teams and individuals keep a vault navigable, role-stable, maintainable, collaboration-friendly,
-            and auditable instead of letting it drift into process logs and scattered notes.
+            and auditable instead of letting it drift into scattered notes and process logs.
           </p>
           <div class="cta-row">
-            <a class="btn primary" href="https://github.com/zouxy111/wiki-knowledgebase-share-kit/blob/main/START-HERE.md">Read START-HERE</a>
-            <a class="btn secondary" href="https://github.com/zouxy111/wiki-knowledgebase-share-kit">Open GitHub repo</a>
-            <a class="btn secondary" href="https://github.com/zouxy111/wiki-knowledgebase-share-kit/releases/latest">Browse release</a>
+            <a class="btn primary" href="https://github.com/zouxy111/wiki-knowledgebase-share-kit">Get the repository</a>
+            <a class="btn secondary" href="https://github.com/zouxy111/wiki-knowledgebase-share-kit/blob/main/START-HERE.md">Read START-HERE</a>
+            <a class="btn secondary" href="https://github.com/zouxy111/wiki-knowledgebase-share-kit/releases/latest">Browse latest release</a>
           </div>
-          <div class="tag-row">
-            <span class="tag">project</span>
-            <span class="tag">knowledge</span>
-            <span class="tag">ops</span>
-            <span class="tag">task</span>
-            <span class="tag">overview</span>
+          <div class="chip-row">
+            <span class="chip">project</span>
+            <span class="chip">knowledge</span>
+            <span class="chip">ops</span>
+            <span class="chip">task</span>
+            <span class="chip">overview</span>
           </div>
-          <p class="micro-note">
-            The page-role model stays fixed. <code>work-journal</code> remains a separate workflow rather than a sixth page role.
+          <p class="hero-note">
+            The fixed page-role model stays stable. <code>work-journal</code> remains a separate workflow rather than a sixth page role.
           </p>
         </article>
 
         <aside class="panel hero-side">
-          <div class="metric-block">
-            <div class="metric-card">
+          <div class="stats-grid">
+            <div class="stat-card">
               <span class="muted">Installable skills</span>
               <strong>8</strong>
-              <span>kit-guide, orchestrator, ingest, maintenance, audit, working-profile, team-coordination, work-journal</span>
+              <span class="muted">kit-guide, orchestrator, ingest, maintenance, audit, working-profile, team-coordination, work-journal</span>
             </div>
-            <div class="metric-card">
+            <div class="stat-card">
               <span class="muted">Workflow tracks</span>
               <strong>7</strong>
-              <span>onboarding, ingest, maintenance, audit, working profile, team coordination, work journal</span>
+              <span class="muted">onboarding, ingest, maintenance, audit, working profile, team coordination, work journal</span>
             </div>
           </div>
 
-          <div class="preview-frame">
+          <div class="clone-card">
+            <div class="role-label">Repository</div>
+            <h3>Clone it directly</h3>
+            <p class="muted">If you want the actual repository instead of only browsing the landing page, start here.</p>
+            <pre><code>git clone https://github.com/zouxy111/wiki-knowledgebase-share-kit.git</code></pre>
+          </div>
+
+          <div class="preview-shell">
             <div class="preview-topbar">
               <span class="dot"></span>
               <span class="dot"></span>
               <span class="dot"></span>
-              <span class="preview-meta">Product preview</span>
+              <span>Landing page preview</span>
             </div>
             <img src="./assets/social-preview.png" alt="Wiki Knowledge Base Share Kit preview" />
           </div>
@@ -608,7 +569,7 @@
         <div class="section-head">
           <div>
             <h2>Why this package exists</h2>
-            <p class="sub">The goal is not to help you record more notes. It is to stop a vault from decaying into a maze of folders, dead links, mixed page roles, and hard-to-reuse knowledge.</p>
+            <p class="sub">The point is not to write more notes. The point is to stop a vault from decaying into a maze of folders, mixed page roles, broken navigation, and hard-to-reuse knowledge.</p>
           </div>
         </div>
         <div class="compare-shell">
@@ -630,7 +591,7 @@
               </tr>
               <tr>
                 <td class="muted">Long-form sources are imported as one big blob and become difficult to revisit.</td>
-                <td class="muted">Sources are split into overview / chapter / topic structures with lineage and better retrieval surfaces.</td>
+                <td class="muted">Sources are split into overview / chapter / topic structures with lineage and retrieval surfaces.</td>
               </tr>
               <tr>
                 <td class="muted">Collaboration context sits in chat, meeting notes, and personal memory.</td>
@@ -647,49 +608,49 @@
         <div class="section-head">
           <div>
             <h2>What’s inside</h2>
-            <p class="sub">The repository keeps the package explicit: 8 public skills, one fixed page-role model, and a small set of repeatable workflows rather than an opaque automation black box.</p>
+            <p class="sub">The repository keeps the package explicit: 8 public skills, one fixed page-role model, and a small set of repeatable workflows rather than a black-box automation promise.</p>
           </div>
         </div>
         <div class="grid-4">
           <article class="section-card">
             <div class="role-label">onboarding</div>
             <h3>knowledge-base-kit-guide</h3>
-            <p>Explains installation, profile setup, and which skill to use next.</p>
+            <p class="card-copy">Explains installation, profile setup, and which skill to use next.</p>
           </article>
           <article class="section-card">
             <div class="role-label">orchestration</div>
             <h3>knowledge-base-orchestrator</h3>
-            <p>Provides low-friction onboarding: inspect the current environment, create a skeleton, generate a profile, and route the next step.</p>
+            <p class="card-copy">Provides low-friction onboarding: inspect the environment, create a skeleton, generate a profile, and route the next step.</p>
           </article>
           <article class="section-card">
             <div class="role-label">ingest</div>
             <h3>knowledge-base-ingest</h3>
-            <p>Imports long-form markdown with a baseline-first, test-driven, lightweight-harness workflow.</p>
+            <p class="card-copy">Imports long-form markdown with a baseline-first, test-driven, lightweight-harness workflow.</p>
           </article>
           <article class="section-card">
             <div class="role-label">maintenance</div>
             <h3>knowledge-base-maintenance</h3>
-            <p>Writes durable conclusions back into the right page role while filtering one-off process noise.</p>
+            <p class="card-copy">Writes durable conclusions back into the right page role while filtering one-off process noise.</p>
           </article>
           <article class="section-card">
             <div class="role-label">audit</div>
             <h3>knowledge-base-audit</h3>
-            <p>Inspects metadata, dead links, orphan pages, boundary drift, and noise regression.</p>
+            <p class="card-copy">Inspects metadata, dead links, orphan pages, boundary drift, and noise regression.</p>
           </article>
           <article class="section-card">
             <div class="role-label">working profile</div>
             <h3>knowledge-base-working-profile</h3>
-            <p>Distills collaboration-relevant preferences, heuristics, and boundaries without turning them into a private dossier.</p>
+            <p class="card-copy">Distills collaboration-relevant preferences, heuristics, and boundaries without turning them into a private dossier.</p>
           </article>
           <article class="section-card">
             <div class="role-label">team coordination</div>
             <h3>knowledge-base-team-coordination</h3>
-            <p>Coordinates shared-project questionnaires, alignment, assignments, and decision distillation.</p>
+            <p class="card-copy">Coordinates questionnaires, alignment, assignments, and closeout decision distillation.</p>
           </article>
           <article class="section-card">
             <div class="role-label">work journal</div>
             <h3>work-journal</h3>
-            <p>Captures daily work, meeting notes, and temporary ideas that can later feed durable knowledge.</p>
+            <p class="card-copy">Captures daily work, meeting notes, and temporary ideas that can later feed durable knowledge.</p>
           </article>
         </div>
       </div>
@@ -700,20 +661,20 @@
         <div class="section-head">
           <div>
             <h2>One method, several high-density scenarios</h2>
-            <p class="sub">This package is especially strong in environments that are knowledge-dense, frequently updated, collaboration-heavy, and in need of traceability and auditability.</p>
+            <p class="sub">This package is strongest in environments that are knowledge-dense, frequently updated, collaboration-heavy, and in need of traceability and auditability.</p>
           </div>
         </div>
         <div class="grid-3">
-          <article class="scenario-card">
+          <article class="mini-card">
             <h3>Medical / pathology / research</h3>
             <p>Guidelines, textbooks, papers, and case summaries need structure, lineage, and careful update boundaries.</p>
             <ul>
               <li>Long-form source ingest</li>
-              <li>Stable method and ops pages</li>
+              <li>Stable knowledge and ops pages</li>
               <li>Review-friendly collaboration context</li>
             </ul>
           </article>
-          <article class="scenario-card">
+          <article class="mini-card">
             <h3>Enterprise knowledge bases</h3>
             <p>PRDs, runbooks, delivery docs, and meeting conclusions need reliable navigation and governance instead of ad hoc sprawl.</p>
             <ul>
@@ -722,9 +683,9 @@
               <li>Cleaner onboarding for teammates</li>
             </ul>
           </article>
-          <article class="scenario-card">
+          <article class="mini-card">
             <h3>Cross-team collaboration</h3>
-            <p>When context is fragmented across chat and temporary docs, shared coordination and journal workflows help prevent repeated re-explanation.</p>
+            <p>When context is fragmented across chat and temporary docs, shared coordination and journal workflows reduce repeated re-explanation.</p>
             <ul>
               <li>Draft / approved boundaries</li>
               <li>Traceable meeting and decision context</li>
@@ -774,68 +735,60 @@
     </section>
 
     <section class="section">
-      <div class="shell">
-        <div class="section-head">
-          <div>
-            <h2>Fixed page-role model</h2>
-            <p class="sub">The package stays stable because page boundaries are explicit. It does not rely on every contributor improvising structure from scratch.</p>
-          </div>
-        </div>
-        <div class="grid-2">
-          <article class="role-card">
-            <div class="role-label">fixed roles</div>
-            <h3>5 durable page roles</h3>
-            <ul>
-              <li><code>project</code> for navigation, overview, and boundaries</li>
-              <li><code>knowledge</code> for reusable methods and concepts</li>
-              <li><code>ops</code> for troubleshooting and procedures</li>
-              <li><code>task</code> for assignments and in-progress work</li>
-              <li><code>overview</code> for indexes and governance surfaces</li>
-            </ul>
-          </article>
-          <article class="role-card">
-            <div class="role-label">boundary note</div>
-            <h3>Journal is not a sixth role</h3>
-            <p><code>work-journal</code> remains a separate workflow. Journal content is allowed to be more fluid, but durable knowledge should be promoted into the fixed page-role model instead of staying in the journal forever.</p>
-          </article>
-        </div>
+      <div class="shell grid-2">
+        <article class="mini-card">
+          <div class="role-label">fixed model</div>
+          <h3>5 durable page roles</h3>
+          <ul>
+            <li><code>project</code> for navigation, overview, and boundaries</li>
+            <li><code>knowledge</code> for reusable methods and concepts</li>
+            <li><code>ops</code> for troubleshooting and procedures</li>
+            <li><code>task</code> for assignments and in-progress work</li>
+            <li><code>overview</code> for indexes and governance surfaces</li>
+          </ul>
+        </article>
+        <article class="mini-card">
+          <div class="role-label">boundary note</div>
+          <h3>Journal is not a sixth role</h3>
+          <p>Journal content can be more fluid, but durable knowledge should be promoted into the fixed page-role model instead of remaining in the journal forever.</p>
+        </article>
       </div>
     </section>
 
     <section class="section">
       <div class="shell cta-band">
-        <article class="cta-card primary">
-          <div class="eyebrow">Start with the right surface</div>
-          <h2>Use the HTML page for product overview, the README for method details.</h2>
-          <p class="sub">This landing page is meant to explain the package quickly. The repository README remains the authoritative place for installation, routing, and workflow boundaries.</p>
+        <article class="section-card">
+          <div class="eyebrow">Get started from the right surface</div>
+          <h2>Use the HTML page for overview, the repository for the actual package.</h2>
+          <p class="sub">This landing page is designed for quick understanding. The GitHub repository remains the authoritative surface for installation, routing, documentation, and release artifacts.</p>
           <div class="cta-row">
-            <a class="btn primary" href="https://github.com/zouxy111/wiki-knowledgebase-share-kit/blob/main/START-HERE.md">Go to START-HERE</a>
-            <a class="btn secondary" href="https://github.com/zouxy111/wiki-knowledgebase-share-kit">Open repository</a>
+            <a class="btn primary" href="https://github.com/zouxy111/wiki-knowledgebase-share-kit">Open GitHub repository</a>
+            <a class="btn secondary" href="https://github.com/zouxy111/wiki-knowledgebase-share-kit/blob/main/START-HERE.md">Go to START-HERE</a>
           </div>
         </article>
-        <article class="cta-card">
-          <div class="role-label">What to open next</div>
-          <h3>Recommended entrypoints</h3>
+        <article class="mini-card">
+          <div class="role-label">Next surfaces</div>
+          <h3>Open these next</h3>
           <ul>
             <li><a href="https://github.com/zouxy111/wiki-knowledgebase-share-kit/blob/main/START-HERE.md">START-HERE.md</a></li>
             <li><a href="https://github.com/zouxy111/wiki-knowledgebase-share-kit/blob/main/GLOSSARY.md">GLOSSARY.md</a></li>
             <li><a href="https://github.com/zouxy111/wiki-knowledgebase-share-kit/blob/main/docs/example-prompts.md">docs/example-prompts.md</a></li>
-            <li><a href="https://github.com/zouxy111/wiki-knowledgebase-share-kit/blob/main/docs/usage-sop.md">docs/usage-sop.md</a></li>
             <li><a href="https://github.com/zouxy111/wiki-knowledgebase-share-kit/releases/latest">Latest release</a></li>
+            <li><a href="https://github.com/zouxy111/wiki-knowledgebase-share-kit/issues">Issues</a></li>
           </ul>
         </article>
       </div>
     </section>
   </main>
 
-  <div class="shell">
+  <div class="shell footer-wrap">
     <footer class="footer-card">
       <div>
         <strong>Wiki Knowledge Base Share Kit</strong>
         <div class="muted">Open source under MIT · Built by 邹星宇 and 杨琦</div>
       </div>
       <div class="footer-links">
-        <a href="https://github.com/zouxy111/wiki-knowledgebase-share-kit">GitHub</a>
+        <a href="https://github.com/zouxy111/wiki-knowledgebase-share-kit">GitHub repo</a>
         <a href="https://github.com/zouxy111/wiki-knowledgebase-share-kit/releases">Releases</a>
         <a href="https://github.com/zouxy111/wiki-knowledgebase-share-kit/issues">Issues</a>
       </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -29,6 +29,7 @@
     * { box-sizing: border-box; }
     html { scroll-behavior: smooth; }
     body {
+      position: relative;
       margin: 0;
       color: var(--text);
       line-height: 1.65;
@@ -37,6 +38,13 @@
         radial-gradient(circle at 12% 12%, rgba(105, 211, 255, 0.18), transparent 24%),
         radial-gradient(circle at 88% 18%, rgba(150, 166, 255, 0.16), transparent 26%),
         linear-gradient(180deg, #08121f 0%, #07111f 45%, #050b14 100%);
+    }
+
+    .site-header,
+    main,
+    .footer-wrap {
+      position: relative;
+      z-index: 1;
     }
 
     a { color: inherit; text-decoration: none; }
@@ -207,6 +215,167 @@
       border: 1px solid var(--line);
       background: rgba(255,255,255,.024);
       box-shadow: var(--shadow-soft);
+    }
+
+    .ambient-backdrop {
+      position: fixed;
+      inset: 0;
+      z-index: 0;
+      pointer-events: none;
+      overflow: hidden;
+    }
+
+    .ambient-aurora,
+    .ambient-floor,
+    .ambient-illustration {
+      position: absolute;
+      inset: auto 0 0 0;
+    }
+
+    .ambient-aurora {
+      inset: auto 50% -10vh 50%;
+      width: min(1200px, 92vw);
+      height: 48vh;
+      transform: translateX(-50%);
+      background:
+        radial-gradient(circle at 48% 62%, rgba(86, 255, 176, .22), transparent 24%),
+        radial-gradient(circle at 38% 68%, rgba(105, 211, 255, .16), transparent 26%),
+        radial-gradient(circle at 62% 58%, rgba(154, 102, 255, .14), transparent 22%);
+      filter: blur(32px);
+      opacity: .72;
+      animation: auroraPulse 10s ease-in-out infinite alternate;
+    }
+
+    .ambient-floor {
+      left: 50%;
+      bottom: -12vh;
+      width: min(1400px, 110vw);
+      height: 46vh;
+      transform: translateX(-50%) perspective(880px) rotateX(72deg);
+      transform-origin: center top;
+      opacity: .34;
+      background:
+        linear-gradient(180deg, rgba(0,0,0,0), rgba(0,0,0,.18)),
+        repeating-linear-gradient(90deg, rgba(108,255,177,.18) 0 1px, transparent 1px 64px),
+        repeating-linear-gradient(0deg, rgba(108,255,177,.14) 0 1px, transparent 1px 52px);
+      mask-image: linear-gradient(180deg, rgba(0,0,0,.0), rgba(0,0,0,.95) 18%, rgba(0,0,0,.95) 100%);
+      animation: floorShift 16s linear infinite;
+    }
+
+    .ambient-illustration {
+      left: 50%;
+      top: 86px;
+      bottom: auto;
+      width: min(1120px, 88vw);
+      height: min(42vh, 360px);
+      transform: translateX(-50%);
+      opacity: .28;
+      mix-blend-mode: screen;
+      filter: drop-shadow(0 0 20px rgba(100, 255, 177, .14));
+      mask-image: linear-gradient(180deg, rgba(0,0,0,.95), rgba(0,0,0,.75) 62%, rgba(0,0,0,0));
+    }
+
+    .ambient-illustration svg {
+      width: 100%;
+      height: 100%;
+      overflow: visible;
+    }
+
+    .ambient-illustration .brain-shell {
+      fill: none;
+      stroke: url(#brainGlow);
+      stroke-width: 3;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      opacity: .9;
+    }
+
+    .ambient-illustration .brain-core {
+      fill: none;
+      stroke: rgba(148, 225, 255, .48);
+      stroke-width: 2;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      opacity: .92;
+    }
+
+    .ambient-illustration .connector {
+      fill: none;
+      stroke: url(#wireGlow);
+      stroke-width: 4;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-dasharray: 14 18;
+      animation: wirePulse 7s linear infinite;
+      opacity: .94;
+    }
+
+    .ambient-illustration .connector-core {
+      fill: none;
+      stroke: rgba(130, 255, 204, .45);
+      stroke-width: 2;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+    }
+
+    .ambient-illustration .usb-shell,
+    .ambient-illustration .usb-detail {
+      fill: none;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+    }
+
+    .ambient-illustration .usb-shell {
+      stroke: rgba(145, 245, 215, .7);
+      stroke-width: 3;
+    }
+
+    .ambient-illustration .usb-detail {
+      stroke: rgba(105, 211, 255, .52);
+      stroke-width: 2;
+    }
+
+    .ambient-illustration .pulse {
+      fill: rgba(110, 255, 188, .82);
+      filter: drop-shadow(0 0 12px rgba(110, 255, 188, .75));
+      animation: nodeBeat 3.4s ease-in-out infinite;
+      transform-origin: center;
+    }
+
+    .ambient-illustration .pulse:nth-of-type(2) { animation-delay: .5s; }
+    .ambient-illustration .pulse:nth-of-type(3) { animation-delay: 1s; }
+    .ambient-illustration .pulse:nth-of-type(4) { animation-delay: 1.5s; }
+
+    .clone-head {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 12px;
+      flex-wrap: wrap;
+      margin-bottom: 10px;
+    }
+
+    .copy-btn {
+      padding: 9px 12px;
+      border-radius: 999px;
+      border: 1px solid rgba(105, 211, 255, .26);
+      background: rgba(255,255,255,.04);
+      color: #dff6ff;
+      cursor: pointer;
+      transition: transform .25s ease, border-color .25s ease, background .25s ease, color .25s ease;
+    }
+
+    .copy-btn:hover {
+      transform: translateY(-1px);
+      border-color: rgba(136, 241, 208, .46);
+      background: rgba(136, 241, 208, .08);
+    }
+
+    .copy-btn.is-copied {
+      color: #07111f;
+      border-color: transparent;
+      background: linear-gradient(135deg, rgba(105,211,255,.96), rgba(136,241,208,.9));
+      box-shadow: 0 12px 24px rgba(105,211,255,.2);
     }
 
     .panel {
@@ -705,6 +874,26 @@
       to { transform: translate3d(-16px, -12px, 0) scale(1.08); }
     }
 
+    @keyframes auroraPulse {
+      from { transform: translateX(-50%) scale(1) translateY(0); opacity: .55; }
+      to { transform: translateX(-50%) scale(1.08) translateY(-8px); opacity: .82; }
+    }
+
+    @keyframes floorShift {
+      from { background-position: 0 0, 0 0, 0 0; }
+      to { background-position: 0 0, 64px 0, 0 52px; }
+    }
+
+    @keyframes wirePulse {
+      from { stroke-dashoffset: 0; }
+      to { stroke-dashoffset: -128; }
+    }
+
+    @keyframes nodeBeat {
+      0%, 100% { transform: scale(1); opacity: .86; }
+      50% { transform: scale(1.35); opacity: 1; }
+    }
+
     @media (max-width: 1100px) {
       .grid-4 { grid-template-columns: repeat(2, minmax(0, 1fr)); }
       .flow { grid-template-columns: repeat(3, minmax(0, 1fr)); }
@@ -752,6 +941,15 @@
       .compare-shell { overflow-x: auto; }
       .compare-shell table { min-width: 620px; }
       .overview-shell { padding: 18px; }
+      .ambient-illustration {
+        width: 112vw;
+        left: 50%;
+        top: 88px;
+        bottom: auto;
+        height: 220px;
+        opacity: .22;
+      }
+      .copy-btn { width: 100%; justify-content: center; }
     }
 
     @media (prefers-reduced-motion: reduce) {
@@ -764,10 +962,49 @@
         opacity: 1 !important;
         transform: none !important;
       }
+      .ambient-aurora,
+      .ambient-floor,
+      .ambient-illustration .connector,
+      .ambient-illustration .pulse,
+      .hero-copy::after {
+        animation: none !important;
+      }
     }
   </style>
 </head>
 <body>
+  <div class="ambient-backdrop" aria-hidden="true">
+    <div class="ambient-aurora"></div>
+    <div class="ambient-floor"></div>
+    <div class="ambient-illustration">
+      <svg viewBox="0 0 1200 460" role="presentation">
+        <defs>
+          <linearGradient id="brainGlow" x1="160" y1="150" x2="640" y2="320" gradientUnits="userSpaceOnUse">
+            <stop stop-color="#73ffbc" stop-opacity="1" />
+            <stop offset=".55" stop-color="#6edcff" stop-opacity=".95" />
+            <stop offset="1" stop-color="#a27cff" stop-opacity=".72" />
+          </linearGradient>
+          <linearGradient id="wireGlow" x1="600" y1="225" x2="1040" y2="245" gradientUnits="userSpaceOnUse">
+            <stop stop-color="#6affb6" stop-opacity=".88" />
+            <stop offset=".6" stop-color="#6edcff" stop-opacity=".85" />
+            <stop offset="1" stop-color="#76ffd2" stop-opacity=".92" />
+          </linearGradient>
+        </defs>
+
+        <path class="brain-shell" d="M230 256C183 252 151 218 154 174C157 137 185 114 214 111C214 67 249 44 284 51C304 23 351 21 381 49C420 36 461 55 476 90C520 92 555 126 555 174C555 212 532 242 494 253C492 304 449 334 404 325C381 356 333 360 297 334C250 346 203 319 190 275C176 272 166 266 154 254" />
+        <path class="brain-core" d="M259 116C247 160 254 208 282 244M316 88C307 137 316 198 347 243M380 87C386 134 383 193 364 238M435 109C447 150 444 198 420 240M220 176C256 171 286 181 307 207M344 189C371 173 407 172 441 191M242 261C280 246 332 248 367 270M382 269C417 254 453 253 487 265" />
+        <path class="connector" d="M556 208C636 208 645 168 705 168C781 168 785 252 863 252C928 252 961 224 1034 224" />
+        <path class="connector-core" d="M556 228C636 228 650 188 706 188C782 188 787 272 864 272C928 272 966 244 1036 244" />
+        <circle class="pulse" cx="588" cy="208" r="6" />
+        <circle class="pulse" cx="720" cy="168" r="6" />
+        <circle class="pulse" cx="868" cy="252" r="6" />
+        <circle class="pulse" cx="1034" cy="224" r="7" />
+        <path class="usb-shell" d="M1040 194H1128C1144 194 1158 208 1158 224V274C1158 290 1144 304 1128 304H1040V194Z" />
+        <path class="usb-shell" d="M1128 212H1168V286H1128" />
+        <path class="usb-detail" d="M1080 212V286M1102 212V286M1168 228H1188M1168 270H1188" />
+      </svg>
+    </div>
+  </div>
   <header class="site-header reveal" style="--delay: 30ms;">
     <div class="shell nav">
       <div class="brand">
@@ -832,10 +1069,13 @@
           </div>
 
           <div class="clone-card reveal" style="--delay: 240ms;">
-            <div class="role-label" data-i18n="cloneLabel">Repository</div>
+            <div class="clone-head">
+              <div class="role-label" data-i18n="cloneLabel">Repository</div>
+              <button type="button" class="copy-btn" data-copy-command="git clone https://github.com/zouxy111/wiki-knowledgebase-share-kit.git">Copy clone</button>
+            </div>
             <h3 data-i18n="cloneTitle">Clone it directly</h3>
             <p class="muted" data-i18n="cloneCopy">If you want the actual repository instead of only browsing the landing page, start here.</p>
-            <pre><code>git clone https://github.com/zouxy111/wiki-knowledgebase-share-kit.git</code></pre>
+            <pre><code data-clone-command>git clone https://github.com/zouxy111/wiki-knowledgebase-share-kit.git</code></pre>
           </div>
 
           <div class="preview-shell reveal" style="--delay: 270ms;">
@@ -1194,6 +1434,9 @@
         cloneLabel: "Repository",
         cloneTitle: "Clone it directly",
         cloneCopy: "If you want the actual repository instead of only browsing the landing page, start here.",
+        copyCloneIdle: "Copy clone",
+        copyCloneDone: "Copied",
+        copyCloneFail: "Copy failed",
         previewLabel: "Landing page preview",
         previewAlt: "Wiki Knowledge Base Share Kit preview",
         overviewTitle: "How the package is organized",
@@ -1311,6 +1554,9 @@
         cloneLabel: "仓库入口",
         cloneTitle: "直接拉仓库",
         cloneCopy: "如果你想拿到真正的仓库，而不只是浏览这个落地页，直接从这里开始。",
+        copyCloneIdle: "复制命令",
+        copyCloneDone: "已复制",
+        copyCloneFail: "复制失败",
         previewLabel: "首页预览",
         previewAlt: "Wiki Knowledge Base Share Kit 预览图",
         overviewTitle: "这个包的结构怎么组织",
@@ -1415,6 +1661,8 @@
     const i18nTextNodes = document.querySelectorAll('[data-i18n]');
     const i18nHtmlNodes = document.querySelectorAll('[data-i18n-html]');
     const i18nAltNodes = document.querySelectorAll('[data-i18n-alt]');
+    const copyButtons = Array.from(document.querySelectorAll('[data-copy-command]'));
+    let currentLocale = 'en';
 
     function updateLangIndicator(activeButton) {
       if (!langSwitch || !activeButton) return;
@@ -1429,6 +1677,7 @@
     function applyLanguage(lang) {
       const locale = translations[lang] ? lang : 'en';
       const dict = translations[locale];
+      currentLocale = locale;
 
       document.documentElement.lang = locale === 'zh' ? 'zh-CN' : 'en';
       document.title = dict.pageTitle;
@@ -1454,8 +1703,39 @@
       });
 
       updateLangIndicator(toggleButtons.find((button) => button.dataset.langToggle === locale));
+      syncCopyLabels();
 
       localStorage.setItem('wiki-kit-lang', locale);
+    }
+
+    function syncCopyLabels() {
+      const dict = translations[currentLocale] || translations.en;
+      copyButtons.forEach((button) => {
+        const state = button.dataset.copyState || 'idle';
+        if (state === 'done') {
+          button.textContent = dict.copyCloneDone;
+        } else if (state === 'fail') {
+          button.textContent = dict.copyCloneFail;
+        } else {
+          button.textContent = dict.copyCloneIdle;
+        }
+      });
+    }
+
+    async function copyText(value) {
+      if (navigator.clipboard && window.isSecureContext) {
+        await navigator.clipboard.writeText(value);
+        return;
+      }
+      const textarea = document.createElement('textarea');
+      textarea.value = value;
+      textarea.setAttribute('readonly', '');
+      textarea.style.position = 'absolute';
+      textarea.style.left = '-9999px';
+      document.body.appendChild(textarea);
+      textarea.select();
+      document.execCommand('copy');
+      textarea.remove();
     }
 
     function initLanguage() {
@@ -1495,6 +1775,29 @@
 
     toggleButtons.forEach((button) => {
       button.addEventListener('click', () => applyLanguage(button.dataset.langToggle));
+    });
+
+    copyButtons.forEach((button) => {
+      button.addEventListener('click', async () => {
+        const command = button.dataset.copyCommand;
+        const dict = translations[currentLocale] || translations.en;
+        try {
+          await copyText(command);
+          button.dataset.copyState = 'done';
+          button.classList.add('is-copied');
+          button.textContent = dict.copyCloneDone;
+        } catch (error) {
+          button.dataset.copyState = 'fail';
+          button.classList.remove('is-copied');
+          button.textContent = dict.copyCloneFail;
+        }
+        window.clearTimeout(button._copyTimer);
+        button._copyTimer = window.setTimeout(() => {
+          button.dataset.copyState = 'idle';
+          button.classList.remove('is-copied');
+          syncCopyLabels();
+        }, 1800);
+      });
     });
 
     window.addEventListener('resize', () => {

--- a/docs/index.html
+++ b/docs/index.html
@@ -346,6 +346,103 @@
     .ambient-illustration .pulse:nth-of-type(3) { animation-delay: 1s; }
     .ambient-illustration .pulse:nth-of-type(4) { animation-delay: 1.5s; }
 
+    .ambient-illustration {
+      top: 74px;
+      width: min(1180px, 90vw);
+      height: min(46vh, 390px);
+      opacity: .42;
+      filter: drop-shadow(0 0 28px rgba(100, 255, 177, .12));
+    }
+
+    .ambient-illustration .hud-arc,
+    .ambient-illustration .brain-fold,
+    .ambient-illustration .brain-lobe,
+    .ambient-illustration .drive-shell,
+    .ambient-illustration .drive-top,
+    .ambient-illustration .drive-plate,
+    .ambient-illustration .drive-port {
+      fill: none;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+    }
+
+    .ambient-illustration .hud-arc {
+      stroke: rgba(105, 211, 255, .18);
+      stroke-width: 2;
+      stroke-dasharray: 4 12;
+      animation: hudOrbit 14s linear infinite;
+    }
+
+    .ambient-illustration .brain-lobe {
+      stroke: url(#brainShellGlow);
+      stroke-width: 3.4;
+      fill: rgba(42, 124, 255, .05);
+    }
+
+    .ambient-illustration .brain-fold {
+      stroke: rgba(124, 221, 255, .28);
+      stroke-width: 2.1;
+    }
+
+    .ambient-illustration .data-stream {
+      fill: none;
+      stroke: url(#streamGlow);
+      stroke-width: 3.2;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-dasharray: 10 16;
+      animation: dataFlow 5.2s linear infinite;
+    }
+
+    .ambient-illustration .data-stream.soft {
+      stroke: rgba(110, 220, 255, .48);
+      stroke-width: 2;
+      stroke-dasharray: 5 12;
+      animation-duration: 7.8s;
+    }
+
+    .ambient-illustration .neuron-node {
+      fill: #aefbff;
+      opacity: .9;
+      filter: drop-shadow(0 0 10px rgba(110, 220, 255, .8));
+      animation: nodeBlink 3.4s ease-in-out infinite;
+      transform-origin: center;
+    }
+
+    .ambient-illustration .neuron-node:nth-of-type(2n) { animation-delay: .6s; }
+    .ambient-illustration .neuron-node:nth-of-type(3n) { animation-delay: 1.1s; }
+
+    .ambient-illustration .drive-shell {
+      stroke: rgba(223, 242, 255, .34);
+      stroke-width: 3;
+      fill: rgba(8, 13, 24, .18);
+    }
+
+    .ambient-illustration .drive-top {
+      stroke: rgba(216, 238, 255, .3);
+      stroke-width: 2.2;
+      fill: rgba(255,255,255,.04);
+    }
+
+    .ambient-illustration .drive-plate {
+      stroke: rgba(140, 210, 255, .24);
+      stroke-width: 2;
+    }
+
+    .ambient-illustration .drive-port {
+      stroke: rgba(110, 220, 255, .38);
+      stroke-width: 2;
+    }
+
+    .ambient-illustration .drive-led {
+      fill: rgba(110, 255, 188, .92);
+      filter: drop-shadow(0 0 10px rgba(110, 255, 188, .7));
+      animation: ledPulse 2.2s ease-in-out infinite;
+    }
+
+    .ambient-illustration .drive-led:nth-of-type(2) { animation-delay: .5s; fill: rgba(110, 220, 255, .92); }
+    .ambient-illustration .drive-led:nth-of-type(3) { animation-delay: 1s; fill: rgba(255, 233, 110, .88); }
+
     .clone-head {
       display: flex;
       align-items: center;
@@ -399,6 +496,29 @@
     .hero-copy {
       position: relative;
       isolation: isolate;
+      display: flex;
+      flex-direction: column;
+      min-height: 100%;
+      background:
+        linear-gradient(180deg, rgba(9, 18, 34, .62), rgba(9, 18, 34, .34)),
+        radial-gradient(circle at 68% 24%, rgba(105,211,255,.08), transparent 34%),
+        rgba(8, 18, 31, .22);
+      backdrop-filter: blur(14px) saturate(1.08);
+      border-color: rgba(255,255,255,.08);
+    }
+
+    .hero-copy::before {
+      content: "";
+      position: absolute;
+      inset: 0;
+      background:
+        linear-gradient(180deg, rgba(255,255,255,.02), rgba(255,255,255,0)),
+        radial-gradient(circle at 50% 100%, rgba(105,211,255,.08), transparent 46%),
+        repeating-linear-gradient(0deg, rgba(255,255,255,.02) 0 1px, transparent 1px 14px),
+        repeating-linear-gradient(90deg, rgba(255,255,255,.012) 0 1px, transparent 1px 18px);
+      opacity: .46;
+      pointer-events: none;
+      mask-image: linear-gradient(180deg, rgba(0,0,0,.78), rgba(0,0,0,.92) 65%, rgba(0,0,0,.38));
     }
 
     .hero-copy::after {
@@ -438,12 +558,19 @@
       line-height: .95;
       letter-spacing: -.05em;
       max-width: 10ch;
+      position: relative;
+      z-index: 1;
     }
 
     html[lang="zh-CN"] h1 {
-      font-size: clamp(36px, 5.2vw, 64px);
-      line-height: 1.02;
-      max-width: 8.8ch;
+      font-size: clamp(34px, 4.9vw, 58px);
+      line-height: 1.03;
+      max-width: 11.2ch;
+      letter-spacing: -.04em;
+    }
+
+    h1 span {
+      display: inline-block;
     }
 
     h2 {
@@ -524,13 +651,47 @@
       font-size: 14px;
     }
 
+    .hero-mini-grid {
+      margin-top: auto;
+      display: grid;
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+      gap: 12px;
+      position: relative;
+      z-index: 1;
+      padding-top: 18px;
+    }
+
+    .hero-mini-card {
+      padding: 14px;
+      border-radius: 18px;
+      border: 1px solid rgba(255,255,255,.08);
+      background: linear-gradient(180deg, rgba(255,255,255,.05), rgba(255,255,255,.02));
+      backdrop-filter: blur(6px);
+    }
+
+    .hero-mini-card strong {
+      display: block;
+      margin-bottom: 6px;
+      font-size: 15px;
+      letter-spacing: -.01em;
+    }
+
+    .hero-mini-card span {
+      display: block;
+      color: var(--muted);
+      font-size: 13px;
+      line-height: 1.55;
+    }
+
     .hero-side {
       display: grid;
       gap: 16px;
       background:
-        radial-gradient(circle at top right, rgba(105,211,255,.15), transparent 38%),
-        linear-gradient(180deg, rgba(255,255,255,.03), rgba(255,255,255,.015)),
-        var(--panel-2);
+        radial-gradient(circle at top right, rgba(105,211,255,.12), transparent 38%),
+        linear-gradient(180deg, rgba(9, 18, 34, .72), rgba(9, 18, 34, .42)),
+        rgba(8, 18, 31, .22);
+      backdrop-filter: blur(16px) saturate(1.06);
+      border-color: rgba(255,255,255,.08);
     }
 
     .stats-grid,
@@ -548,7 +709,7 @@
 
     .stat-card,
     .clone-card,
-    .preview-shell {
+    .switcher-shell {
       border-radius: var(--radius-lg);
       padding: 18px;
       background: rgba(255,255,255,.03);
@@ -576,37 +737,158 @@
       font-size: 13px;
     }
 
-    .preview-shell {
-      padding: 0;
+    .switcher-shell {
+      display: grid;
+      gap: 16px;
       overflow: hidden;
     }
 
-    .preview-topbar {
+    .switcher-head {
+      display: flex;
+      align-items: flex-start;
+      justify-content: space-between;
+      gap: 14px;
+    }
+
+    .switcher-head h3 {
+      margin-bottom: 6px;
+    }
+
+    .switcher-head p {
+      margin: 0;
+      color: var(--muted);
+      font-size: 14px;
+    }
+
+    .switcher-controls {
+      display: flex;
+      gap: 10px;
+      flex: 0 0 auto;
+    }
+
+    .switcher-btn,
+    .switcher-dot {
+      border: 1px solid rgba(255,255,255,.12);
+      background: rgba(255,255,255,.04);
+      color: #dff6ff;
+      cursor: pointer;
+      transition: transform .25s ease, border-color .25s ease, background .25s ease;
+    }
+
+    .switcher-btn {
+      width: 40px;
+      height: 40px;
+      border-radius: 999px;
+      display: grid;
+      place-items: center;
+      font-size: 18px;
+    }
+
+    .switcher-btn:hover,
+    .switcher-dot:hover {
+      transform: translateY(-1px);
+      border-color: rgba(136, 241, 208, .38);
+      background: rgba(136, 241, 208, .08);
+    }
+
+    .switcher-viewport {
+      overflow: hidden;
+      border-radius: 20px;
+      border: 1px solid rgba(255,255,255,.06);
+      background:
+        radial-gradient(circle at top right, rgba(105,211,255,.10), transparent 34%),
+        linear-gradient(180deg, rgba(255,255,255,.025), rgba(255,255,255,.015));
+      touch-action: pan-y;
+    }
+
+    .switcher-track {
+      display: flex;
+      transition: transform .46s cubic-bezier(.22, 1, .36, 1);
+      will-change: transform;
+    }
+
+    .switcher-slide {
+      min-width: 100%;
+      padding: 22px;
+      display: grid;
+      gap: 14px;
+    }
+
+    .switcher-kicker {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: fit-content;
+      padding: 6px 10px;
+      border-radius: 999px;
+      border: 1px solid rgba(105,211,255,.16);
+      background: rgba(105,211,255,.06);
+      color: var(--accent);
+      font-size: 12px;
+      letter-spacing: .14em;
+      text-transform: uppercase;
+    }
+
+    .switcher-slide h4 {
+      margin: 0;
+      font-size: 24px;
+      line-height: 1.15;
+      letter-spacing: -.02em;
+    }
+
+    .switcher-slide p {
+      margin: 0;
+      color: var(--muted);
+    }
+
+    .switcher-slide ul {
+      margin: 0;
+      padding-left: 18px;
+      color: var(--muted);
+      display: grid;
+      gap: 8px;
+    }
+
+    .switcher-note {
+      padding: 12px 14px;
+      border-radius: 16px;
+      border: 1px solid rgba(255,255,255,.06);
+      background: rgba(255,255,255,.03);
+      color: #dff6ff;
+      font-size: 14px;
+    }
+
+    .switcher-footer {
       display: flex;
       align-items: center;
-      gap: 8px;
-      padding: 14px 16px;
-      border-bottom: 1px solid var(--line);
-      background: rgba(255,255,255,.03);
+      justify-content: space-between;
+      gap: 12px;
+      flex-wrap: wrap;
     }
 
-    .dot { width: 10px; height: 10px; border-radius: 999px; }
-    .dot:nth-child(1) { background: #ff6b6b; }
-    .dot:nth-child(2) { background: #ffd166; }
-    .dot:nth-child(3) { background: #7ae582; }
+    .switcher-dots {
+      display: flex;
+      gap: 10px;
+    }
 
-    .preview-topbar span:last-child {
-      margin-left: auto;
+    .switcher-dot {
+      width: 10px;
+      height: 10px;
+      border-radius: 999px;
+      padding: 0;
+    }
+
+    .switcher-dot.is-active {
+      background: linear-gradient(135deg, rgba(105,211,255,.96), rgba(136,241,208,.9));
+      border-color: transparent;
+      box-shadow: 0 0 0 6px rgba(105,211,255,.08);
+    }
+
+    .switcher-status {
       color: var(--muted);
-      font-size: 12px;
+      font-size: 13px;
+      letter-spacing: .08em;
       text-transform: uppercase;
-      letter-spacing: .16em;
-    }
-
-    .preview-shell img {
-      width: 100%;
-      height: auto;
-      object-fit: cover;
     }
 
     .section {
@@ -750,7 +1032,7 @@
     .mini-card:hover,
     .stat-card:hover,
     .clone-card:hover,
-    .preview-shell:hover {
+    .switcher-shell:hover {
       transform: translateY(-4px);
       border-color: var(--line-strong);
       box-shadow: 0 18px 38px rgba(0,0,0,.24);
@@ -894,6 +1176,27 @@
       50% { transform: scale(1.35); opacity: 1; }
     }
 
+    @keyframes dataFlow {
+      from { stroke-dashoffset: 0; }
+      to { stroke-dashoffset: -120; }
+    }
+
+    @keyframes nodeBlink {
+      0%, 100% { transform: scale(1); opacity: .48; }
+      40% { transform: scale(1.32); opacity: 1; }
+      60% { transform: scale(.92); opacity: .88; }
+    }
+
+    @keyframes ledPulse {
+      0%, 100% { opacity: .55; transform: scale(1); }
+      50% { opacity: 1; transform: scale(1.18); }
+    }
+
+    @keyframes hudOrbit {
+      from { stroke-dashoffset: 0; opacity: .12; }
+      to { stroke-dashoffset: -110; opacity: .32; }
+    }
+
     @media (max-width: 1100px) {
       .grid-4 { grid-template-columns: repeat(2, minmax(0, 1fr)); }
       .flow { grid-template-columns: repeat(3, minmax(0, 1fr)); }
@@ -927,7 +1230,8 @@
       .btn { width: 100%; justify-content: center; }
       .stats-grid,
       .grid-4,
-      .flow { grid-template-columns: 1fr; }
+      .flow,
+      .hero-mini-grid { grid-template-columns: 1fr; }
       .hero-copy,
       .hero-side,
       .section-card,
@@ -948,6 +1252,13 @@
         bottom: auto;
         height: 220px;
         opacity: .22;
+      }
+      .switcher-head {
+        flex-direction: column;
+        align-items: stretch;
+      }
+      .switcher-controls {
+        align-self: flex-start;
       }
       .copy-btn { width: 100%; justify-content: center; }
     }
@@ -979,29 +1290,60 @@
     <div class="ambient-illustration">
       <svg viewBox="0 0 1200 460" role="presentation">
         <defs>
-          <linearGradient id="brainGlow" x1="160" y1="150" x2="640" y2="320" gradientUnits="userSpaceOnUse">
-            <stop stop-color="#73ffbc" stop-opacity="1" />
-            <stop offset=".55" stop-color="#6edcff" stop-opacity=".95" />
-            <stop offset="1" stop-color="#a27cff" stop-opacity=".72" />
+          <linearGradient id="brainShellGlow" x1="270" y1="92" x2="802" y2="292" gradientUnits="userSpaceOnUse">
+            <stop stop-color="#88f1d0" stop-opacity=".96" />
+            <stop offset=".42" stop-color="#6edcff" stop-opacity=".94" />
+            <stop offset="1" stop-color="#7fb7ff" stop-opacity=".82" />
           </linearGradient>
-          <linearGradient id="wireGlow" x1="600" y1="225" x2="1040" y2="245" gradientUnits="userSpaceOnUse">
-            <stop stop-color="#6affb6" stop-opacity=".88" />
-            <stop offset=".6" stop-color="#6edcff" stop-opacity=".85" />
-            <stop offset="1" stop-color="#76ffd2" stop-opacity=".92" />
+          <linearGradient id="streamGlow" x1="540" y1="166" x2="640" y2="390" gradientUnits="userSpaceOnUse">
+            <stop stop-color="#c4ffff" stop-opacity=".96" />
+            <stop offset=".42" stop-color="#6edcff" stop-opacity=".95" />
+            <stop offset="1" stop-color="#76ffd2" stop-opacity=".88" />
           </linearGradient>
         </defs>
 
-        <path class="brain-shell" d="M230 256C183 252 151 218 154 174C157 137 185 114 214 111C214 67 249 44 284 51C304 23 351 21 381 49C420 36 461 55 476 90C520 92 555 126 555 174C555 212 532 242 494 253C492 304 449 334 404 325C381 356 333 360 297 334C250 346 203 319 190 275C176 272 166 266 154 254" />
-        <path class="brain-core" d="M259 116C247 160 254 208 282 244M316 88C307 137 316 198 347 243M380 87C386 134 383 193 364 238M435 109C447 150 444 198 420 240M220 176C256 171 286 181 307 207M344 189C371 173 407 172 441 191M242 261C280 246 332 248 367 270M382 269C417 254 453 253 487 265" />
-        <path class="connector" d="M556 208C636 208 645 168 705 168C781 168 785 252 863 252C928 252 961 224 1034 224" />
-        <path class="connector-core" d="M556 228C636 228 650 188 706 188C782 188 787 272 864 272C928 272 966 244 1036 244" />
-        <circle class="pulse" cx="588" cy="208" r="6" />
-        <circle class="pulse" cx="720" cy="168" r="6" />
-        <circle class="pulse" cx="868" cy="252" r="6" />
-        <circle class="pulse" cx="1034" cy="224" r="7" />
-        <path class="usb-shell" d="M1040 194H1128C1144 194 1158 208 1158 224V274C1158 290 1144 304 1128 304H1040V194Z" />
-        <path class="usb-shell" d="M1128 212H1168V286H1128" />
-        <path class="usb-detail" d="M1080 212V286M1102 212V286M1168 228H1188M1168 270H1188" />
+        <path class="hud-arc" d="M220 200C330 64 528 32 666 92C720 116 764 150 808 206" />
+        <path class="hud-arc" d="M314 330C404 372 510 382 606 356C714 326 780 274 844 198" />
+
+        <path class="brain-lobe" d="M338 274C282 270 240 234 238 188C236 150 258 118 292 102C302 70 340 44 382 48C414 22 470 20 508 50C548 34 592 48 620 80C646 82 676 98 692 126C722 178 694 252 642 278C632 322 592 348 548 344C520 370 470 374 430 350C382 360 332 338 314 296C302 292 294 286 338 274Z" />
+        <path class="brain-lobe" d="M858 274C914 270 956 234 958 188C960 150 938 118 904 102C894 70 856 44 814 48C782 22 726 20 688 50C648 34 604 48 576 80C550 82 520 98 504 126C474 178 502 252 554 278C564 322 604 348 648 344C676 370 726 374 766 350C814 360 864 338 882 296C894 292 902 286 858 274Z" />
+
+        <path class="brain-fold" d="M384 96C352 130 350 188 378 234M444 72C424 120 424 192 456 250M520 68C506 120 508 190 530 248M604 82C604 132 598 198 572 250" />
+        <path class="brain-fold" d="M816 96C848 130 850 188 822 234M756 72C776 120 776 192 744 250M680 68C694 120 692 190 670 248M596 82C596 132 602 198 628 250" />
+        <path class="brain-fold" d="M336 184C390 170 446 184 488 214M712 214C754 184 810 170 864 184M382 286C432 260 500 258 556 282M646 282C702 258 770 260 820 286" />
+
+        <path class="data-stream" d="M596 296V356" />
+        <path class="data-stream" d="M620 290V360" />
+        <path class="data-stream soft" d="M572 288V354" />
+        <path class="data-stream soft" d="M644 286V354" />
+        <path class="data-stream" d="M520 214C548 214 562 236 582 250V338" />
+        <path class="data-stream" d="M464 184C516 184 540 210 562 236" />
+        <path class="data-stream soft" d="M408 150C476 150 520 176 556 218" />
+        <path class="data-stream" d="M672 214C644 214 630 236 610 250V338" />
+        <path class="data-stream" d="M728 184C676 184 652 210 630 236" />
+        <path class="data-stream soft" d="M784 150C716 150 672 176 636 218" />
+
+        <circle class="neuron-node" cx="408" cy="150" r="5" />
+        <circle class="neuron-node" cx="464" cy="184" r="4.5" />
+        <circle class="neuron-node" cx="520" cy="214" r="4.5" />
+        <circle class="neuron-node" cx="572" cy="288" r="4.5" />
+        <circle class="neuron-node" cx="620" cy="290" r="4.5" />
+        <circle class="neuron-node" cx="672" cy="214" r="4.5" />
+        <circle class="neuron-node" cx="728" cy="184" r="4.5" />
+        <circle class="neuron-node" cx="784" cy="150" r="5" />
+
+        <path class="drive-shell" d="M372 304H826C844 304 860 320 860 338V404C860 422 844 438 826 438H372C354 438 338 422 338 404V338C338 320 354 304 372 304Z" />
+        <path class="drive-top" d="M368 304H830L804 276H394L368 304Z" />
+        <path class="drive-plate" d="M426 320H770C786 320 800 334 800 350V394C800 410 786 424 770 424H426C410 424 396 410 396 394V350C396 334 410 320 426 320Z" />
+        <path class="drive-plate" d="M516 334C548 320 650 320 684 334C706 344 714 364 708 386C700 410 668 424 634 426H564C520 424 484 406 482 378C480 360 492 342 516 334Z" />
+        <path class="drive-port" d="M420 370H470M484 370H516M540 370H560M640 388H716M730 388H764M782 388H794" />
+        <path class="drive-port" d="M416 402H510V420H416Z" />
+        <path class="drive-port" d="M648 404H712V420H648Z" />
+        <path class="drive-port" d="M732 396H786V420H732Z" />
+
+        <circle class="drive-led" cx="442" cy="350" r="5" />
+        <circle class="drive-led" cx="468" cy="350" r="5" />
+        <circle class="drive-led" cx="494" cy="350" r="5" />
       </svg>
     </div>
   </div>
@@ -1033,7 +1375,7 @@
       <div class="shell hero-grid">
         <article class="panel hero-copy reveal" style="--delay: 90ms;">
           <div class="eyebrow" data-i18n="heroEyebrow">Structured knowledge, not note sprawl</div>
-          <h1 data-i18n="heroTitle">Turn your markdown vault into a usable knowledge base.</h1>
+          <h1 data-i18n-html="heroTitle">Turn your<br><span>markdown vault</span> into a<br>usable knowledge base.</h1>
           <p class="lede" data-i18n="heroLede">
             A reusable open-source package with 8 installable skills and 7 coordinated workflow tracks. It helps teams and individuals keep a vault navigable, role-stable, maintainable, collaboration-friendly, and auditable instead of letting it drift into scattered notes and process logs.
           </p>
@@ -1052,6 +1394,20 @@
           <p class="hero-note" data-i18n-html="heroNote">
             The fixed page-role model stays stable. <code>work-journal</code> remains a separate workflow rather than a sixth page role.
           </p>
+          <div class="hero-mini-grid">
+            <article class="hero-mini-card">
+              <strong data-i18n="heroMini1Title">Role-stable structure</strong>
+              <span data-i18n="heroMini1Copy">Keep project, knowledge, ops, task, and overview pages from drifting into each other.</span>
+            </article>
+            <article class="hero-mini-card">
+              <strong data-i18n="heroMini2Title">Testable ingest workflow</strong>
+              <span data-i18n="heroMini2Copy">Import long-form markdown with iteration, comparison, and lightweight regression checks.</span>
+            </article>
+            <article class="hero-mini-card">
+              <strong data-i18n="heroMini3Title">Collaboration without chaos</strong>
+              <span data-i18n="heroMini3Copy">Working profile, team coordination, and journal loops reduce repeated re-explanation.</span>
+            </article>
+          </div>
         </article>
 
         <aside class="panel hero-side reveal" style="--delay: 150ms;">
@@ -1068,7 +1424,70 @@
             </div>
           </div>
 
-          <div class="clone-card reveal" style="--delay: 240ms;">
+          <div class="switcher-shell reveal" style="--delay: 240ms;">
+            <div class="switcher-head">
+              <div>
+                <div class="role-label" data-i18n="switcherLabel">Use-case switcher</div>
+                <h3 data-i18n="switcherTitle">Slide through usage plans</h3>
+                <p data-i18n="switcherSub">Instead of a static preview image, use this panel to see how the package can be applied in different working environments.</p>
+              </div>
+              <div class="switcher-controls">
+                <button type="button" class="switcher-btn" data-switcher-dir="-1" aria-label="Previous">←</button>
+                <button type="button" class="switcher-btn" data-switcher-dir="1" aria-label="Next">→</button>
+              </div>
+            </div>
+
+            <div class="switcher-viewport" data-switcher-viewport>
+              <div class="switcher-track" data-switcher-track>
+                <article class="switcher-slide">
+                  <span class="switcher-kicker" data-i18n="useCase1Kicker">Scenario 01</span>
+                  <h4 data-i18n="scenario1Title">Medical / pathology / research</h4>
+                  <p data-i18n="scenario1Copy">Guidelines, textbooks, papers, and case summaries need structure, lineage, and careful update boundaries.</p>
+                  <ul data-i18n-html="scenario1List">
+                    <li>Long-form source ingest</li>
+                    <li>Stable knowledge and ops pages</li>
+                    <li>Review-friendly collaboration context</li>
+                  </ul>
+                  <div class="switcher-note" data-i18n="useCase1Note">Recommended route: Orchestrator → Ingest → Audit → Working Profile.</div>
+                </article>
+
+                <article class="switcher-slide">
+                  <span class="switcher-kicker" data-i18n="useCase2Kicker">Scenario 02</span>
+                  <h4 data-i18n="scenario2Title">Enterprise knowledge bases</h4>
+                  <p data-i18n="scenario2Copy">PRDs, runbooks, delivery docs, and meeting conclusions need reliable navigation and governance instead of ad hoc sprawl.</p>
+                  <ul data-i18n-html="scenario2List">
+                    <li>Maintenance and audit loops</li>
+                    <li>Shared-project coordination</li>
+                    <li>Cleaner onboarding for teammates</li>
+                  </ul>
+                  <div class="switcher-note" data-i18n="useCase2Note">Recommended route: Kit Guide → Maintenance → Audit → Team Coordination.</div>
+                </article>
+
+                <article class="switcher-slide">
+                  <span class="switcher-kicker" data-i18n="useCase3Kicker">Scenario 03</span>
+                  <h4 data-i18n="scenario3Title">Cross-team collaboration</h4>
+                  <p data-i18n="scenario3Copy">When context is fragmented across chat and temporary docs, shared coordination and journal workflows reduce repeated re-explanation.</p>
+                  <ul data-i18n-html="scenario3List">
+                    <li>Draft / approved boundaries</li>
+                    <li>Traceable meeting and decision context</li>
+                    <li>Working-profile hygiene with consent boundaries</li>
+                  </ul>
+                  <div class="switcher-note" data-i18n="useCase3Note">Recommended route: Work Journal → Team Coordination → Maintenance → Audit.</div>
+                </article>
+              </div>
+            </div>
+
+            <div class="switcher-footer">
+              <div class="switcher-dots">
+                <button type="button" class="switcher-dot is-active" data-switcher-to="0" aria-label="Go to scenario 1"></button>
+                <button type="button" class="switcher-dot" data-switcher-to="1" aria-label="Go to scenario 2"></button>
+                <button type="button" class="switcher-dot" data-switcher-to="2" aria-label="Go to scenario 3"></button>
+              </div>
+              <span class="switcher-status" data-switcher-status>01 / 03</span>
+            </div>
+          </div>
+
+          <div class="clone-card reveal" style="--delay: 270ms;">
             <div class="clone-head">
               <div class="role-label" data-i18n="cloneLabel">Repository</div>
               <button type="button" class="copy-btn" data-copy-command="git clone https://github.com/zouxy111/wiki-knowledgebase-share-kit.git">Copy clone</button>
@@ -1076,16 +1495,6 @@
             <h3 data-i18n="cloneTitle">Clone it directly</h3>
             <p class="muted" data-i18n="cloneCopy">If you want the actual repository instead of only browsing the landing page, start here.</p>
             <pre><code data-clone-command>git clone https://github.com/zouxy111/wiki-knowledgebase-share-kit.git</code></pre>
-          </div>
-
-          <div class="preview-shell reveal" style="--delay: 270ms;">
-            <div class="preview-topbar">
-              <span class="dot"></span>
-              <span class="dot"></span>
-              <span class="dot"></span>
-              <span data-i18n="previewLabel">Landing page preview</span>
-            </div>
-            <img src="./assets/social-preview.png" alt="Wiki Knowledge Base Share Kit preview" data-i18n-alt="previewAlt" />
           </div>
         </aside>
       </div>
@@ -1421,12 +1830,18 @@
         navStart: "Start Here",
         navRelease: "Latest release",
         heroEyebrow: "Structured knowledge, not note sprawl",
-        heroTitle: "Turn your markdown vault into a usable knowledge base.",
+        heroTitle: "Turn your<br><span>markdown vault</span> into a<br>usable knowledge base.",
         heroLede: "A reusable open-source package with 8 installable skills and 7 coordinated workflow tracks. It helps teams and individuals keep a vault navigable, role-stable, maintainable, collaboration-friendly, and auditable instead of letting it drift into scattered notes and process logs.",
         heroCtaRepo: "Get the repository",
         heroCtaStart: "Read START-HERE",
         heroCtaRelease: "Browse latest release",
         heroNote: "The fixed page-role model stays stable. <code>work-journal</code> remains a separate workflow rather than a sixth page role.",
+        heroMini1Title: "Role-stable structure",
+        heroMini1Copy: "Keep project, knowledge, ops, task, and overview pages from drifting into each other.",
+        heroMini2Title: "Testable ingest workflow",
+        heroMini2Copy: "Import long-form markdown with iteration, comparison, and lightweight regression checks.",
+        heroMini3Title: "Collaboration without chaos",
+        heroMini3Copy: "Working profile, team coordination, and journal loops reduce repeated re-explanation.",
         statsSkillsLabel: "Installable skills",
         statsSkillsCopy: "kit-guide, orchestrator, ingest, maintenance, audit, working-profile, team-coordination, work-journal",
         statsTracksLabel: "Workflow tracks",
@@ -1437,8 +1852,15 @@
         copyCloneIdle: "Copy clone",
         copyCloneDone: "Copied",
         copyCloneFail: "Copy failed",
-        previewLabel: "Landing page preview",
-        previewAlt: "Wiki Knowledge Base Share Kit preview",
+        switcherLabel: "Use-case switcher",
+        switcherTitle: "Slide through usage plans",
+        switcherSub: "Instead of a static preview image, use this panel to see how the package can be applied in different working environments.",
+        useCase1Kicker: "Scenario 01",
+        useCase1Note: "Recommended route: Orchestrator → Ingest → Audit → Working Profile.",
+        useCase2Kicker: "Scenario 02",
+        useCase2Note: "Recommended route: Kit Guide → Maintenance → Audit → Team Coordination.",
+        useCase3Kicker: "Scenario 03",
+        useCase3Note: "Recommended route: Work Journal → Team Coordination → Maintenance → Audit.",
         overviewTitle: "How the package is organized",
         overviewSub: "Think of the repository as a layered operating surface: onboarding first, specialist loops in the middle, collaboration support beside them, and a stable vault shape as the output.",
         overviewCol1Label: "entry",
@@ -1541,12 +1963,18 @@
         navStart: "快速开始",
         navRelease: "最新版本",
         heroEyebrow: "结构化知识，而不是笔记蔓延",
-        heroTitle: "把 markdown vault 变成真正可用的知识库。",
+        heroTitle: "把 <span>markdown vault</span><br>变成真正可用的<br>知识库。",
         heroLede: "这是一个可复用的开源工作包，包含 8 个可安装 skills 和 7 条协同工作流。它帮助个人和团队让 vault 保持可导航、角色稳定、可维护、便于协作、可审计，而不是继续漂成零散笔记和过程流水账。",
         heroCtaRepo: "获取仓库",
         heroCtaStart: "阅读 START-HERE",
         heroCtaRelease: "查看最新版本",
         heroNote: "固定的 page-role model 会保持稳定。<code>work-journal</code> 是独立工作流，不是第六种页面角色。",
+        heroMini1Title: "结构角色稳定",
+        heroMini1Copy: "让 project、knowledge、ops、task、overview 不再互相串位、互相污染。",
+        heroMini2Title: "导入可测试可迭代",
+        heroMini2Copy: "长篇 markdown 导入时可做版本对比、结构迭代和轻量回归检查。",
+        heroMini3Title: "协作上下文不再失控",
+        heroMini3Copy: "working profile、team coordination、journal 形成可追溯的协作层，而不是重复解释。",
         statsSkillsLabel: "可安装 skills",
         statsSkillsCopy: "kit-guide、orchestrator、ingest、maintenance、audit、working-profile、team-coordination、work-journal",
         statsTracksLabel: "工作流轨道",
@@ -1557,8 +1985,15 @@
         copyCloneIdle: "复制命令",
         copyCloneDone: "已复制",
         copyCloneFail: "复制失败",
-        previewLabel: "首页预览",
-        previewAlt: "Wiki Knowledge Base Share Kit 预览图",
+        switcherLabel: "方案切换",
+        switcherTitle: "左右切换使用方案",
+        switcherSub: "这里不再放静态预览图，而是直接展示这个包在不同工作环境里的用法方案。",
+        useCase1Kicker: "方案 01",
+        useCase1Note: "推荐路线：Orchestrator → Ingest → Audit → Working Profile。",
+        useCase2Kicker: "方案 02",
+        useCase2Note: "推荐路线：Kit Guide → Maintenance → Audit → Team Coordination。",
+        useCase3Kicker: "方案 03",
+        useCase3Note: "推荐路线：Work Journal → Team Coordination → Maintenance → Audit。",
         overviewTitle: "这个包的结构怎么组织",
         overviewSub: "你可以把这个仓库理解成一个分层工作面：先 onboarding，中间是 specialist loops，旁边是协作支撑层，最后输出成稳定的 vault 形态。",
         overviewCol1Label: "入口层",
@@ -1662,7 +2097,13 @@
     const i18nHtmlNodes = document.querySelectorAll('[data-i18n-html]');
     const i18nAltNodes = document.querySelectorAll('[data-i18n-alt]');
     const copyButtons = Array.from(document.querySelectorAll('[data-copy-command]'));
+    const switcherTrack = document.querySelector('[data-switcher-track]');
+    const switcherViewport = document.querySelector('[data-switcher-viewport]');
+    const switcherDots = Array.from(document.querySelectorAll('[data-switcher-to]'));
+    const switcherButtons = Array.from(document.querySelectorAll('[data-switcher-dir]'));
+    const switcherStatus = document.querySelector('[data-switcher-status]');
     let currentLocale = 'en';
+    let currentScenario = 0;
 
     function updateLangIndicator(activeButton) {
       if (!langSwitch || !activeButton) return;
@@ -1773,6 +2214,55 @@
       });
     }
 
+    function renderSwitcher(index) {
+      if (!switcherTrack) return;
+      const total = switcherDots.length || switcherTrack.children.length || 1;
+      currentScenario = (index + total) % total;
+      switcherTrack.style.transform = `translateX(-${currentScenario * 100}%)`;
+      switcherDots.forEach((dot, dotIndex) => {
+        dot.classList.toggle('is-active', dotIndex === currentScenario);
+      });
+      if (switcherStatus) {
+        switcherStatus.textContent = `${String(currentScenario + 1).padStart(2, '0')} / ${String(total).padStart(2, '0')}`;
+      }
+    }
+
+    function initSwitcher() {
+      if (!switcherTrack) return;
+      renderSwitcher(0);
+
+      switcherButtons.forEach((button) => {
+        button.addEventListener('click', () => {
+          renderSwitcher(currentScenario + Number(button.dataset.switcherDir || 0));
+        });
+      });
+
+      switcherDots.forEach((dot) => {
+        dot.addEventListener('click', () => {
+          renderSwitcher(Number(dot.dataset.switcherTo || 0));
+        });
+      });
+
+      if (!switcherViewport) return;
+      let startX = 0;
+      let endX = 0;
+
+      switcherViewport.addEventListener('touchstart', (event) => {
+        startX = event.touches[0].clientX;
+        endX = startX;
+      }, { passive: true });
+
+      switcherViewport.addEventListener('touchmove', (event) => {
+        endX = event.touches[0].clientX;
+      }, { passive: true });
+
+      switcherViewport.addEventListener('touchend', () => {
+        const delta = endX - startX;
+        if (Math.abs(delta) < 40) return;
+        renderSwitcher(currentScenario + (delta < 0 ? 1 : -1));
+      });
+    }
+
     toggleButtons.forEach((button) => {
       button.addEventListener('click', () => applyLanguage(button.dataset.langToggle));
     });
@@ -1805,6 +2295,7 @@
     });
 
     initLanguage();
+    initSwitcher();
     if (document.readyState === 'loading') {
       window.addEventListener('DOMContentLoaded', initReveal, { once: true });
     } else {

--- a/docs/index.html
+++ b/docs/index.html
@@ -118,6 +118,34 @@
       flex-wrap: wrap;
     }
 
+    .lang-switch {
+      position: relative;
+      padding: 4px;
+      border-radius: 999px;
+      border: 1px solid rgba(255,255,255,.08);
+      background: rgba(255,255,255,.02);
+      overflow: hidden;
+      isolation: isolate;
+    }
+
+    .lang-switch::before {
+      content: "";
+      position: absolute;
+      inset: 4px;
+      left: var(--lang-indicator-left, 4px);
+      width: var(--lang-indicator-width, calc(50% - 4px));
+      border-radius: 999px;
+      background: linear-gradient(135deg, rgba(105,211,255,.92), rgba(136,241,208,.84));
+      box-shadow: 0 10px 24px rgba(105,211,255,.22);
+      transition: left .34s cubic-bezier(.22, 1, .36, 1), width .34s cubic-bezier(.22, 1, .36, 1), opacity .25s ease;
+      z-index: -1;
+    }
+
+    .lang-switch.is-switching::before {
+      opacity: .92;
+      filter: saturate(1.1) brightness(1.04);
+    }
+
     .pill,
     .btn,
     .chip,
@@ -145,13 +173,16 @@
     .lang-btn {
       cursor: pointer;
       min-width: 54px;
+      position: relative;
+      z-index: 1;
     }
 
     .lang-btn.active {
       color: #07111f;
       border-color: transparent;
-      background: linear-gradient(135deg, var(--accent), #84a7ff 52%, var(--accent-2));
-      box-shadow: 0 10px 24px rgba(105,211,255,.22);
+      background: transparent;
+      box-shadow: none;
+      transform: translateY(-1px);
     }
 
     .hero {
@@ -410,7 +441,34 @@
     }
 
     .section {
+      position: relative;
       padding: 28px 0;
+    }
+
+    .section::before {
+      content: "";
+      position: absolute;
+      top: 0;
+      left: 50%;
+      width: min(980px, 76vw);
+      height: 1px;
+      transform: translateX(-50%);
+      background: linear-gradient(90deg, transparent, rgba(105,211,255,.55), rgba(136,241,208,.45), transparent);
+      opacity: .72;
+    }
+
+    .section::after {
+      content: "";
+      position: absolute;
+      top: -32px;
+      left: 50%;
+      width: min(760px, 58vw);
+      height: 110px;
+      transform: translateX(-50%);
+      background: radial-gradient(circle, rgba(105,211,255,.14), transparent 68%);
+      filter: blur(28px);
+      opacity: .38;
+      pointer-events: none;
     }
 
     .section-head {
@@ -428,6 +486,88 @@
     .grid-3 { grid-template-columns: repeat(3, minmax(0, 1fr)); }
     .grid-4 { grid-template-columns: repeat(4, minmax(0, 1fr)); }
     .flow { grid-template-columns: repeat(5, minmax(0, 1fr)); }
+
+    .overview-shell {
+      border: 1px solid var(--line);
+      border-radius: 28px;
+      padding: 22px;
+      background:
+        linear-gradient(180deg, rgba(255,255,255,.03), rgba(255,255,255,.015)),
+        rgba(8, 19, 34, .84);
+      box-shadow: var(--shadow-soft);
+    }
+
+    .overview-grid {
+      display: grid;
+      grid-template-columns: minmax(0, 1.05fr) 40px minmax(0, 1.15fr) 40px minmax(0, 1.05fr) 40px minmax(0, 1fr);
+      gap: 12px;
+      align-items: stretch;
+    }
+
+    .overview-column {
+      border: 1px solid var(--line);
+      border-radius: 22px;
+      background: rgba(255,255,255,.026);
+      padding: 18px;
+      min-width: 0;
+    }
+
+    .overview-column h3 {
+      margin-bottom: 8px;
+      font-size: 18px;
+    }
+
+    .overview-column p {
+      margin: 0 0 14px;
+      color: var(--muted);
+      font-size: 14px;
+    }
+
+    .overview-stack {
+      display: grid;
+      gap: 10px;
+    }
+
+    .overview-node {
+      padding: 12px 14px;
+      border-radius: 16px;
+      border: 1px solid rgba(255,255,255,.08);
+      background: linear-gradient(180deg, rgba(255,255,255,.04), rgba(255,255,255,.015));
+      color: #dfeeff;
+      box-shadow: inset 0 1px 0 rgba(255,255,255,.03);
+    }
+
+    .overview-node strong {
+      display: block;
+      margin-bottom: 4px;
+      font-size: 14px;
+    }
+
+    .overview-node span {
+      display: block;
+      color: var(--muted);
+      font-size: 12px;
+      line-height: 1.5;
+    }
+
+    .overview-arrow {
+      display: grid;
+      place-items: center;
+      color: rgba(136,241,208,.9);
+      font-size: 26px;
+      letter-spacing: -.04em;
+      text-shadow: 0 0 24px rgba(105,211,255,.24);
+    }
+
+    .overview-outcome {
+      display: grid;
+      gap: 10px;
+    }
+
+    .overview-outcome .chip {
+      justify-self: start;
+      background: rgba(255,255,255,.04);
+    }
 
     .section-card,
     .flow-step,
@@ -569,6 +709,13 @@
       .grid-4 { grid-template-columns: repeat(2, minmax(0, 1fr)); }
       .flow { grid-template-columns: repeat(3, minmax(0, 1fr)); }
       .cta-band { grid-template-columns: 1fr; }
+      .overview-grid {
+        grid-template-columns: 1fr;
+      }
+      .overview-arrow {
+        min-height: 20px;
+        transform: rotate(90deg);
+      }
     }
 
     @media (max-width: 980px) {
@@ -604,6 +751,7 @@
       }
       .compare-shell { overflow-x: auto; }
       .compare-shell table { min-width: 620px; }
+      .overview-shell { padding: 18px; }
     }
 
     @media (prefers-reduced-motion: reduce) {
@@ -700,6 +848,95 @@
             <img src="./assets/social-preview.png" alt="Wiki Knowledge Base Share Kit preview" data-i18n-alt="previewAlt" />
           </div>
         </aside>
+      </div>
+    </section>
+
+    <section class="section">
+      <div class="shell">
+        <div class="section-head reveal" style="--delay: 40ms;">
+          <div>
+            <h2 data-i18n="overviewTitle">How the package is organized</h2>
+            <p class="sub" data-i18n="overviewSub">Think of the repository as a layered operating surface: onboarding first, specialist loops in the middle, collaboration support beside them, and a stable vault shape as the output.</p>
+          </div>
+        </div>
+        <div class="overview-shell reveal" style="--delay: 90ms;">
+          <div class="overview-grid">
+            <article class="overview-column reveal" style="--delay: 120ms;">
+              <div class="role-label" data-i18n="overviewCol1Label">entry</div>
+              <h3 data-i18n="overviewCol1Title">Onboarding layer</h3>
+              <p data-i18n="overviewCol1Copy">Start from explanation-first guidance or low-friction setup.</p>
+              <div class="overview-stack">
+                <div class="overview-node">
+                  <strong>knowledge-base-kit-guide</strong>
+                  <span data-i18n="overviewNode1">Installation guide, profile setup, usage routing.</span>
+                </div>
+                <div class="overview-node">
+                  <strong>knowledge-base-orchestrator</strong>
+                  <span data-i18n="overviewNode2">Environment check, vault skeleton, profile bootstrap.</span>
+                </div>
+              </div>
+            </article>
+
+            <div class="overview-arrow reveal is-visible" style="--delay: 0ms;">→</div>
+
+            <article class="overview-column reveal" style="--delay: 150ms;">
+              <div class="role-label" data-i18n="overviewCol2Label">core loops</div>
+              <h3 data-i18n="overviewCol2Title">Knowledge maintenance layer</h3>
+              <p data-i18n="overviewCol2Copy">These are the specialist loops that shape structure, durability, and auditability.</p>
+              <div class="overview-stack">
+                <div class="overview-node">
+                  <strong>knowledge-base-ingest</strong>
+                  <span data-i18n="overviewNode3">Long-form markdown split, linking, and baseline-driven import.</span>
+                </div>
+                <div class="overview-node">
+                  <strong>knowledge-base-maintenance</strong>
+                  <span data-i18n="overviewNode4">Promote durable conclusions into the right page role.</span>
+                </div>
+                <div class="overview-node">
+                  <strong>knowledge-base-audit</strong>
+                  <span data-i18n="overviewNode5">Metadata, links, orphan pages, noise drift, and governance checks.</span>
+                </div>
+              </div>
+            </article>
+
+            <div class="overview-arrow reveal is-visible" style="--delay: 0ms;">→</div>
+
+            <article class="overview-column reveal" style="--delay: 180ms;">
+              <div class="role-label" data-i18n="overviewCol3Label">collaboration</div>
+              <h3 data-i18n="overviewCol3Title">People and coordination layer</h3>
+              <p data-i18n="overviewCol3Copy">Support collaboration without turning the knowledge base into raw chat history.</p>
+              <div class="overview-stack">
+                <div class="overview-node">
+                  <strong>knowledge-base-working-profile</strong>
+                  <span data-i18n="overviewNode6">Collaboration-relevant preferences, heuristics, and boundaries.</span>
+                </div>
+                <div class="overview-node">
+                  <strong>knowledge-base-team-coordination</strong>
+                  <span data-i18n="overviewNode7">Questionnaires, alignment, assignments, and closeout decisions.</span>
+                </div>
+                <div class="overview-node">
+                  <strong>work-journal</strong>
+                  <span data-i18n="overviewNode8">Daily execution notes that can later feed durable knowledge.</span>
+                </div>
+              </div>
+            </article>
+
+            <div class="overview-arrow reveal is-visible" style="--delay: 0ms;">→</div>
+
+            <article class="overview-column reveal" style="--delay: 210ms;">
+              <div class="role-label" data-i18n="overviewCol4Label">outcome</div>
+              <h3 data-i18n="overviewCol4Title">Stable vault output</h3>
+              <p data-i18n="overviewCol4Copy">The final target is not more pages, but a vault whose roles and navigation remain legible over time.</p>
+              <div class="overview-outcome">
+                <span class="chip">project</span>
+                <span class="chip">knowledge</span>
+                <span class="chip">ops</span>
+                <span class="chip">task</span>
+                <span class="chip">overview</span>
+              </div>
+            </article>
+          </div>
+        </div>
       </div>
     </section>
 
@@ -959,6 +1196,28 @@
         cloneCopy: "If you want the actual repository instead of only browsing the landing page, start here.",
         previewLabel: "Landing page preview",
         previewAlt: "Wiki Knowledge Base Share Kit preview",
+        overviewTitle: "How the package is organized",
+        overviewSub: "Think of the repository as a layered operating surface: onboarding first, specialist loops in the middle, collaboration support beside them, and a stable vault shape as the output.",
+        overviewCol1Label: "entry",
+        overviewCol1Title: "Onboarding layer",
+        overviewCol1Copy: "Start from explanation-first guidance or low-friction setup.",
+        overviewNode1: "Installation guide, profile setup, usage routing.",
+        overviewNode2: "Environment check, vault skeleton, profile bootstrap.",
+        overviewCol2Label: "core loops",
+        overviewCol2Title: "Knowledge maintenance layer",
+        overviewCol2Copy: "These are the specialist loops that shape structure, durability, and auditability.",
+        overviewNode3: "Long-form markdown split, linking, and baseline-driven import.",
+        overviewNode4: "Promote durable conclusions into the right page role.",
+        overviewNode5: "Metadata, links, orphan pages, noise drift, and governance checks.",
+        overviewCol3Label: "collaboration",
+        overviewCol3Title: "People and coordination layer",
+        overviewCol3Copy: "Support collaboration without turning the knowledge base into raw chat history.",
+        overviewNode6: "Collaboration-relevant preferences, heuristics, and boundaries.",
+        overviewNode7: "Questionnaires, alignment, assignments, and closeout decisions.",
+        overviewNode8: "Daily execution notes that can later feed durable knowledge.",
+        overviewCol4Label: "outcome",
+        overviewCol4Title: "Stable vault output",
+        overviewCol4Copy: "The final target is not more pages, but a vault whose roles and navigation remain legible over time.",
         whyTitle: "Why this package exists",
         whySub: "The point is not to write more notes. The point is to stop a vault from decaying into a maze of folders, mixed page roles, broken navigation, and hard-to-reuse knowledge.",
         whyTableLeft: "Typical drifting vault",
@@ -1054,6 +1313,28 @@
         cloneCopy: "如果你想拿到真正的仓库，而不只是浏览这个落地页，直接从这里开始。",
         previewLabel: "首页预览",
         previewAlt: "Wiki Knowledge Base Share Kit 预览图",
+        overviewTitle: "这个包的结构怎么组织",
+        overviewSub: "你可以把这个仓库理解成一个分层工作面：先 onboarding，中间是 specialist loops，旁边是协作支撑层，最后输出成稳定的 vault 形态。",
+        overviewCol1Label: "入口层",
+        overviewCol1Title: "Onboarding 层",
+        overviewCol1Copy: "可以从解释优先的引导进入，也可以直接低门槛初始化。",
+        overviewNode1: "安装说明、profile 配置、使用路由。",
+        overviewNode2: "环境检查、vault 骨架、profile 启动。",
+        overviewCol2Label: "核心循环",
+        overviewCol2Title: "知识维护层",
+        overviewCol2Copy: "这些 specialist loops 决定结构、耐久性和可审计性。",
+        overviewNode3: "长篇 markdown 拆分、链接与 baseline 驱动导入。",
+        overviewNode4: "把真正耐久的结论提升回正确页面角色。",
+        overviewNode5: "metadata、链接、孤儿页、噪音漂移与治理检查。",
+        overviewCol3Label: "协作层",
+        overviewCol3Title: "人和协同层",
+        overviewCol3Copy: "为协作提供支撑，但不会把知识库变成原始聊天记录堆。",
+        overviewNode6: "与协作有关的偏好、启发式和边界。",
+        overviewNode7: "问卷、对齐、分工与收尾决策沉淀。",
+        overviewNode8: "日常执行记录，后续可再喂回耐久知识。",
+        overviewCol4Label: "输出层",
+        overviewCol4Title: "稳定的 vault 输出",
+        overviewCol4Copy: "最终目标不是多几页文档，而是让 vault 的角色和导航长期保持清晰。",
         whyTitle: "为什么需要这个包",
         whySub: "重点不是写更多笔记，而是阻止 vault 继续退化成文件夹迷宫、页面角色混杂、导航断裂、知识难以复用的状态。",
         whyTableLeft: "常见的漂移型 vault",
@@ -1130,9 +1411,20 @@
 
     const metaDescription = document.querySelector('meta[name="description"]');
     const toggleButtons = Array.from(document.querySelectorAll('[data-lang-toggle]'));
+    const langSwitch = document.querySelector('.lang-switch');
     const i18nTextNodes = document.querySelectorAll('[data-i18n]');
     const i18nHtmlNodes = document.querySelectorAll('[data-i18n-html]');
     const i18nAltNodes = document.querySelectorAll('[data-i18n-alt]');
+
+    function updateLangIndicator(activeButton) {
+      if (!langSwitch || !activeButton) return;
+      const switchRect = langSwitch.getBoundingClientRect();
+      const buttonRect = activeButton.getBoundingClientRect();
+      langSwitch.style.setProperty('--lang-indicator-left', `${buttonRect.left - switchRect.left}px`);
+      langSwitch.style.setProperty('--lang-indicator-width', `${buttonRect.width}px`);
+      langSwitch.classList.add('is-switching');
+      window.setTimeout(() => langSwitch.classList.remove('is-switching'), 260);
+    }
 
     function applyLanguage(lang) {
       const locale = translations[lang] ? lang : 'en';
@@ -1160,6 +1452,8 @@
       toggleButtons.forEach((button) => {
         button.classList.toggle('active', button.dataset.langToggle === locale);
       });
+
+      updateLangIndicator(toggleButtons.find((button) => button.dataset.langToggle === locale));
 
       localStorage.setItem('wiki-kit-lang', locale);
     }
@@ -1201,6 +1495,10 @@
 
     toggleButtons.forEach((button) => {
       button.addEventListener('click', () => applyLanguage(button.dataset.langToggle));
+    });
+
+    window.addEventListener('resize', () => {
+      updateLangIndicator(toggleButtons.find((button) => button.classList.contains('active')));
     });
 
     initLanguage();

--- a/docs/index.html
+++ b/docs/index.html
@@ -8,246 +8,838 @@
   <style>
     :root {
       --bg: #07111f;
-      --panel: #0d1a2d;
-      --panel-2: #12233c;
+      --bg-2: #09192d;
+      --panel: rgba(10, 21, 38, 0.84);
+      --panel-strong: rgba(12, 26, 46, 0.92);
+      --line: rgba(255,255,255,.10);
+      --line-strong: rgba(255,255,255,.18);
       --text: #ecf4ff;
-      --muted: #9fb1ca;
-      --line: rgba(255,255,255,.08);
-      --accent: #70d7ff;
-      --accent-2: #9bf3d3;
-      --shadow: 0 24px 80px rgba(0,0,0,.35);
-      font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      --muted: #9db1ca;
+      --accent: #69d3ff;
+      --accent-2: #8af2d0;
+      --accent-3: #9aa8ff;
+      --glow: rgba(105, 211, 255, 0.22);
+      --shadow: 0 24px 80px rgba(0,0,0,.30);
+      font-family: Geist, Outfit, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
     }
+
     * { box-sizing: border-box; }
+
+    html { scroll-behavior: smooth; }
+
     body {
       margin: 0;
-      background: radial-gradient(circle at top, #112949 0%, #07111f 48%, #050b14 100%);
       color: var(--text);
       line-height: 1.6;
+      background:
+        radial-gradient(circle at 10% 10%, rgba(105, 211, 255, 0.18), transparent 24%),
+        radial-gradient(circle at 88% 18%, rgba(154, 168, 255, 0.18), transparent 26%),
+        radial-gradient(circle at 50% 100%, rgba(138, 242, 208, 0.10), transparent 28%),
+        linear-gradient(180deg, #081220 0%, #07111f 42%, #050b14 100%);
     }
-    a { color: inherit; }
+
+    a { color: inherit; text-decoration: none; }
+    img { max-width: 100%; display: block; }
     code { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
-    .shell { width: min(1180px, calc(100vw - 40px)); margin: 0 auto; }
-    .hero { padding: 28px 0 72px; }
-    .nav { display:flex; justify-content:space-between; align-items:center; gap:16px; padding: 12px 0 32px; }
-    .brand { font-weight: 700; letter-spacing: .03em; color: #dff5ff; }
-    .nav-links { display:flex; gap:12px; flex-wrap:wrap; }
-    .pill, .btn { text-decoration:none; }
-    .pill { padding: 10px 14px; border-radius: 999px; border:1px solid var(--line); color: var(--muted); }
-    .hero-grid { display:grid; grid-template-columns: 1.7fr 1fr; gap: 20px; }
-    .panel { background: linear-gradient(180deg, rgba(255,255,255,.02), rgba(255,255,255,.01)); border:1px solid var(--line); border-radius: 28px; box-shadow: var(--shadow); }
-    .intro, .stat-card, .card, .step, .compare { padding: 28px; }
-    .eyebrow { color: var(--accent); text-transform: uppercase; letter-spacing: .2em; font-size: 12px; margin-bottom: 18px; }
-    h1 { font-size: clamp(40px, 6vw, 70px); line-height: .95; margin: 0 0 18px; letter-spacing: -.04em; }
-    h2 { margin: 0 0 12px; font-size: clamp(28px, 4vw, 38px); }
-    h3 { margin: 0 0 10px; font-size: 20px; }
-    .lede { font-size: 19px; color: var(--muted); max-width: 62ch; }
-    .cta-row, .chip-row { display:flex; gap:12px; flex-wrap:wrap; margin-top: 20px; }
-    .btn { padding: 14px 18px; border-radius: 16px; border:1px solid var(--line); font-weight:700; }
-    .btn.primary { background: linear-gradient(135deg, var(--accent), #4ab9ff); color:#04101c; }
-    .btn.secondary { color: var(--text); background: rgba(255,255,255,.02); }
-    .chip { padding:8px 12px; border-radius:999px; background: rgba(255,255,255,.05); color: var(--muted); }
-    .metric { font-size: 72px; font-weight: 800; margin: 10px 0 0; letter-spacing: -.04em; }
-    .kicker { color: var(--accent-2); text-transform: uppercase; letter-spacing: .18em; font-size: 12px; }
-    .stat-copy, .sub, .card p, .step span { color: var(--muted); }
-    .section { padding: 0 0 34px; }
-    .sub { max-width: 72ch; margin-bottom: 22px; }
-    .grid-2, .grid-3, .grid-4, .flow { display:grid; gap:20px; }
+
+    .shell {
+      width: min(1240px, calc(100vw - 40px));
+      margin: 0 auto;
+    }
+
+    .site-header {
+      position: sticky;
+      top: 0;
+      z-index: 30;
+      backdrop-filter: blur(16px);
+      background: rgba(7, 17, 31, 0.72);
+      border-bottom: 1px solid rgba(255,255,255,.06);
+    }
+
+    .nav {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 20px;
+      padding: 16px 0;
+    }
+
+    .brand-wrap {
+      display: flex;
+      align-items: center;
+      gap: 14px;
+    }
+
+    .brand-mark {
+      width: 42px;
+      height: 42px;
+      border-radius: 14px;
+      border: 1px solid rgba(255,255,255,.12);
+      background:
+        linear-gradient(135deg, rgba(105, 211, 255, .22), rgba(138, 242, 208, .10)),
+        rgba(255,255,255,.03);
+      display: grid;
+      place-items: center;
+      font-weight: 800;
+      letter-spacing: -.04em;
+      color: #dff6ff;
+      box-shadow: inset 0 1px 0 rgba(255,255,255,.06);
+    }
+
+    .brand-copy strong {
+      display: block;
+      font-size: 15px;
+      letter-spacing: .02em;
+    }
+
+    .brand-copy span {
+      display: block;
+      font-size: 12px;
+      color: var(--muted);
+      letter-spacing: .06em;
+      text-transform: uppercase;
+    }
+
+    .nav-links {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 12px;
+    }
+
+    .pill,
+    .btn,
+    .tag {
+      border: 1px solid var(--line);
+      border-radius: 999px;
+    }
+
+    .pill {
+      padding: 10px 14px;
+      color: var(--muted);
+      background: rgba(255,255,255,.02);
+    }
+
+    .hero {
+      position: relative;
+      overflow: hidden;
+      padding: 52px 0 34px;
+    }
+
+    .hero-grid {
+      display: grid;
+      grid-template-columns: minmax(0, 1.2fr) minmax(360px, .8fr);
+      gap: 22px;
+      align-items: stretch;
+    }
+
+    .panel {
+      position: relative;
+      border: 1px solid var(--line);
+      border-radius: 30px;
+      background:
+        linear-gradient(180deg, rgba(255,255,255,.035), rgba(255,255,255,.015)),
+        var(--panel);
+      box-shadow: var(--shadow);
+      overflow: hidden;
+    }
+
+    .panel::before {
+      content: "";
+      position: absolute;
+      inset: 0;
+      background: linear-gradient(180deg, rgba(255,255,255,.06), transparent 20%);
+      pointer-events: none;
+    }
+
+    .hero-copy,
+    .hero-side,
+    .section-card,
+    .flow-step,
+    .scenario-card,
+    .role-card,
+    .cta-card,
+    .footer-card {
+      padding: 30px;
+    }
+
+    .eyebrow {
+      display: inline-flex;
+      align-items: center;
+      gap: 10px;
+      margin-bottom: 20px;
+      color: var(--accent);
+      text-transform: uppercase;
+      letter-spacing: .22em;
+      font-size: 12px;
+    }
+
+    .eyebrow::before {
+      content: "";
+      width: 28px;
+      height: 1px;
+      background: linear-gradient(90deg, transparent, var(--accent));
+    }
+
+    h1 {
+      margin: 0 0 18px;
+      font-size: clamp(44px, 6vw, 82px);
+      line-height: .94;
+      letter-spacing: -.05em;
+      max-width: 10ch;
+    }
+
+    h2 {
+      margin: 0 0 14px;
+      font-size: clamp(28px, 4vw, 42px);
+      letter-spacing: -.03em;
+    }
+
+    h3 {
+      margin: 0 0 10px;
+      font-size: 22px;
+      letter-spacing: -.02em;
+    }
+
+    .lede {
+      margin: 0;
+      max-width: 62ch;
+      font-size: 18px;
+      color: var(--muted);
+    }
+
+    .cta-row,
+    .tag-row,
+    .stats,
+    .grid-2,
+    .grid-3,
+    .grid-4,
+    .flow {
+      display: grid;
+      gap: 18px;
+    }
+
+    .cta-row {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 14px;
+      margin: 26px 0 22px;
+    }
+
+    .btn {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      gap: 10px;
+      padding: 15px 18px;
+      font-weight: 700;
+      background: rgba(255,255,255,.03);
+    }
+
+    .btn.primary {
+      color: #07111f;
+      background: linear-gradient(135deg, var(--accent), #80a8ff 52%, var(--accent-2));
+      border-color: transparent;
+      box-shadow: 0 16px 40px rgba(105, 211, 255, .24);
+    }
+
+    .btn.secondary:hover,
+    .pill:hover {
+      border-color: var(--line-strong);
+      background: rgba(255,255,255,.05);
+    }
+
+    .tag-row {
+      grid-template-columns: repeat(5, minmax(0, max-content));
+      align-items: start;
+      gap: 10px;
+    }
+
+    .tag {
+      display: inline-flex;
+      padding: 8px 12px;
+      color: var(--muted);
+      background: rgba(255,255,255,.03);
+      font-size: 13px;
+    }
+
+    .micro-note {
+      margin-top: 8px;
+      color: var(--muted);
+      font-size: 14px;
+    }
+
+    .hero-side {
+      display: flex;
+      flex-direction: column;
+      gap: 18px;
+      background:
+        radial-gradient(circle at top right, rgba(105, 211, 255, .14), transparent 38%),
+        linear-gradient(180deg, rgba(255,255,255,.03), rgba(255,255,255,.015)),
+        var(--panel-strong);
+    }
+
+    .metric-block {
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: 14px;
+    }
+
+    .metric-card {
+      padding: 16px;
+      border: 1px solid var(--line);
+      border-radius: 22px;
+      background: rgba(255,255,255,.025);
+    }
+
+    .metric-card strong {
+      display: block;
+      font-size: clamp(34px, 5vw, 54px);
+      letter-spacing: -.05em;
+      line-height: .95;
+      margin-bottom: 8px;
+    }
+
+    .metric-card span,
+    .sub,
+    .card-copy,
+    .flow-step p,
+    .muted {
+      color: var(--muted);
+    }
+
+    .preview-frame {
+      border: 1px solid var(--line);
+      border-radius: 24px;
+      overflow: hidden;
+      background: rgba(255,255,255,.03);
+      box-shadow: inset 0 1px 0 rgba(255,255,255,.05);
+    }
+
+    .preview-topbar {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      padding: 14px 16px;
+      border-bottom: 1px solid var(--line);
+      background: rgba(255,255,255,.03);
+    }
+
+    .dot {
+      width: 10px;
+      height: 10px;
+      border-radius: 999px;
+      background: rgba(255,255,255,.22);
+    }
+
+    .dot:nth-child(1) { background: #ff6b6b; }
+    .dot:nth-child(2) { background: #ffd166; }
+    .dot:nth-child(3) { background: #7ae582; }
+
+    .preview-meta {
+      margin-left: auto;
+      font-size: 12px;
+      color: var(--muted);
+      text-transform: uppercase;
+      letter-spacing: .14em;
+    }
+
+    .preview-frame img {
+      width: 100%;
+      height: auto;
+      object-fit: cover;
+    }
+
+    .section {
+      padding: 24px 0 26px;
+    }
+
+    .section-head {
+      display: flex;
+      flex-wrap: wrap;
+      align-items: end;
+      justify-content: space-between;
+      gap: 18px;
+      margin-bottom: 18px;
+    }
+
+    .sub {
+      max-width: 68ch;
+      margin: 0;
+      font-size: 16px;
+    }
+
     .grid-2 { grid-template-columns: repeat(2, minmax(0,1fr)); }
     .grid-3 { grid-template-columns: repeat(3, minmax(0,1fr)); }
     .grid-4 { grid-template-columns: repeat(4, minmax(0,1fr)); }
     .flow { grid-template-columns: repeat(5, minmax(0,1fr)); }
-    .card p { margin:0; }
-    .compare table { width:100%; border-collapse:collapse; }
-    .compare th, .compare td { padding:16px; border-bottom: 1px solid var(--line); text-align:left; vertical-align:top; }
-    .muted { color: var(--muted); }
-    .step { position:relative; min-height: 170px; }
-    .step small { display:block; color: var(--accent); margin-bottom: 8px; letter-spacing: .18em; }
-    .footer { padding: 18px 0 48px; color: var(--muted); }
-    .preview { overflow:hidden; }
-    .preview img { display:block; width:100%; height:auto; }
-    @media (max-width: 1100px) {
-      .hero-grid, .grid-4, .flow { grid-template-columns: 1fr 1fr; }
+
+    .section-card,
+    .scenario-card,
+    .role-card,
+    .flow-step,
+    .cta-card,
+    .footer-card {
+      border: 1px solid var(--line);
+      border-radius: 28px;
+      background: rgba(255,255,255,.022);
+      min-height: 100%;
     }
+
+    .section-card p,
+    .scenario-card p,
+    .role-card p,
+    .role-card ul,
+    .section-card ul,
+    .scenario-card ul {
+      margin: 0;
+      color: var(--muted);
+    }
+
+    .section-card ul,
+    .scenario-card ul {
+      padding-left: 18px;
+      display: grid;
+      gap: 8px;
+      margin-top: 12px;
+    }
+
+    .role-label {
+      display: inline-flex;
+      margin-bottom: 14px;
+      padding: 7px 10px;
+      border-radius: 999px;
+      border: 1px solid var(--line);
+      color: var(--accent-2);
+      font-size: 12px;
+      text-transform: uppercase;
+      letter-spacing: .16em;
+    }
+
+    .compare-shell {
+      border: 1px solid var(--line);
+      border-radius: 28px;
+      overflow: hidden;
+      background: rgba(255,255,255,.02);
+    }
+
+    .compare-shell table {
+      width: 100%;
+      border-collapse: collapse;
+    }
+
+    .compare-shell th,
+    .compare-shell td {
+      padding: 18px;
+      border-bottom: 1px solid var(--line);
+      vertical-align: top;
+      text-align: left;
+    }
+
+    .compare-shell th {
+      font-size: 14px;
+      color: #dff6ff;
+      background: rgba(255,255,255,.03);
+    }
+
+    .flow-step {
+      position: relative;
+      overflow: hidden;
+    }
+
+    .flow-step small {
+      display: block;
+      margin-bottom: 10px;
+      color: var(--accent);
+      font-size: 12px;
+      letter-spacing: .22em;
+      text-transform: uppercase;
+    }
+
+    .flow-step p {
+      margin: 10px 0 0;
+    }
+
+    .cta-band {
+      display: grid;
+      grid-template-columns: 1.2fr .8fr;
+      gap: 20px;
+      align-items: stretch;
+    }
+
+    .cta-card.primary {
+      background:
+        radial-gradient(circle at top right, rgba(105,211,255,.16), transparent 34%),
+        linear-gradient(135deg, rgba(255,255,255,.05), rgba(255,255,255,.015));
+    }
+
+    .cta-card .cta-row {
+      margin-bottom: 0;
+    }
+
+    .footer-card {
+      display: flex;
+      flex-wrap: wrap;
+      justify-content: space-between;
+      align-items: center;
+      gap: 18px;
+      margin: 0 0 42px;
+    }
+
+    .footer-links {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 12px;
+      color: var(--muted);
+    }
+
+    @media (max-width: 1180px) {
+      .hero-grid,
+      .cta-band,
+      .grid-4,
+      .flow { grid-template-columns: 1fr 1fr; }
+      .tag-row { grid-template-columns: repeat(3, max-content); }
+    }
+
     @media (max-width: 920px) {
-      .hero-grid, .grid-4, .grid-3, .grid-2, .flow { grid-template-columns: 1fr; }
-      .intro, .stat-card, .card, .step, .compare { padding: 22px; }
+      .hero-grid,
+      .cta-band,
+      .grid-4,
+      .grid-3,
+      .grid-2,
+      .flow { grid-template-columns: 1fr; }
+      .hero-copy,
+      .hero-side,
+      .section-card,
+      .flow-step,
+      .scenario-card,
+      .role-card,
+      .cta-card,
+      .footer-card { padding: 24px; }
+      .nav { align-items: flex-start; flex-direction: column; }
+      .tag-row { grid-template-columns: repeat(2, max-content); }
+    }
+
+    @media (max-width: 620px) {
+      .shell { width: min(100vw - 24px, 1240px); }
+      .pill,
+      .btn { width: 100%; justify-content: center; }
+      .nav-links,
+      .cta-row { width: 100%; }
+      .metric-block { grid-template-columns: 1fr; }
+      .tag-row { grid-template-columns: 1fr 1fr; }
     }
   </style>
 </head>
 <body>
-  <div class="shell hero">
-    <div class="nav">
-      <div class="brand">Wiki Knowledge Base Share Kit</div>
+  <header class="site-header">
+    <div class="shell nav">
+      <div class="brand-wrap">
+        <div class="brand-mark">WK</div>
+        <div class="brand-copy">
+          <strong>Wiki Knowledge Base Share Kit</strong>
+          <span>8-skill knowledge-base package</span>
+        </div>
+      </div>
       <div class="nav-links">
         <a class="pill" href="https://github.com/zouxy111/wiki-knowledgebase-share-kit">GitHub</a>
-        <a class="pill" href="https://github.com/zouxy111/wiki-knowledgebase-share-kit/releases">Releases</a>
         <a class="pill" href="https://github.com/zouxy111/wiki-knowledgebase-share-kit/blob/main/START-HERE.md">Start Here</a>
+        <a class="pill" href="https://github.com/zouxy111/wiki-knowledgebase-share-kit/releases/latest">Latest release</a>
       </div>
     </div>
+  </header>
 
-    <div class="hero-grid">
-      <section class="panel intro">
-        <div class="eyebrow">8-skill knowledge-base package</div>
-        <h1>Keep your markdown vault useful, not noisy.</h1>
-        <p class="lede">
-          A reusable open-source kit with 8 installable skills and 7 coordinated workflow tracks: onboarding, ingest,
-          maintenance, audit, working profile, team coordination, and work journaling.
-          Optional Obsidian installation exists through Orchestrator, but the repository’s core value is stable knowledge-base workflows—not being an app installer.
-        </p>
-        <div class="cta-row">
-          <a class="btn primary" href="https://github.com/zouxy111/wiki-knowledgebase-share-kit/blob/main/START-HERE.md">Read START-HERE</a>
-          <a class="btn secondary" href="https://github.com/zouxy111/wiki-knowledgebase-share-kit/releases/latest">Browse latest release</a>
+  <main>
+    <section class="hero">
+      <div class="shell hero-grid">
+        <article class="panel hero-copy">
+          <div class="eyebrow">Structured knowledge, not note sprawl</div>
+          <h1>Turn your markdown vault into a usable knowledge base.</h1>
+          <p class="lede">
+            A reusable open-source package with 8 installable skills and 7 coordinated workflow tracks.
+            It helps teams and individuals keep a vault navigable, role-stable, maintainable, collaboration-friendly,
+            and auditable instead of letting it drift into process logs and scattered notes.
+          </p>
+          <div class="cta-row">
+            <a class="btn primary" href="https://github.com/zouxy111/wiki-knowledgebase-share-kit/blob/main/START-HERE.md">Read START-HERE</a>
+            <a class="btn secondary" href="https://github.com/zouxy111/wiki-knowledgebase-share-kit">Open GitHub repo</a>
+            <a class="btn secondary" href="https://github.com/zouxy111/wiki-knowledgebase-share-kit/releases/latest">Browse release</a>
+          </div>
+          <div class="tag-row">
+            <span class="tag">project</span>
+            <span class="tag">knowledge</span>
+            <span class="tag">ops</span>
+            <span class="tag">task</span>
+            <span class="tag">overview</span>
+          </div>
+          <p class="micro-note">
+            The page-role model stays fixed. <code>work-journal</code> remains a separate workflow rather than a sixth page role.
+          </p>
+        </article>
+
+        <aside class="panel hero-side">
+          <div class="metric-block">
+            <div class="metric-card">
+              <span class="muted">Installable skills</span>
+              <strong>8</strong>
+              <span>kit-guide, orchestrator, ingest, maintenance, audit, working-profile, team-coordination, work-journal</span>
+            </div>
+            <div class="metric-card">
+              <span class="muted">Workflow tracks</span>
+              <strong>7</strong>
+              <span>onboarding, ingest, maintenance, audit, working profile, team coordination, work journal</span>
+            </div>
+          </div>
+
+          <div class="preview-frame">
+            <div class="preview-topbar">
+              <span class="dot"></span>
+              <span class="dot"></span>
+              <span class="dot"></span>
+              <span class="preview-meta">Product preview</span>
+            </div>
+            <img src="./assets/social-preview.png" alt="Wiki Knowledge Base Share Kit preview" />
+          </div>
+        </aside>
+      </div>
+    </section>
+
+    <section class="section">
+      <div class="shell">
+        <div class="section-head">
+          <div>
+            <h2>Why this package exists</h2>
+            <p class="sub">The goal is not to help you record more notes. It is to stop a vault from decaying into a maze of folders, dead links, mixed page roles, and hard-to-reuse knowledge.</p>
+          </div>
         </div>
-        <div class="chip-row">
-          <span class="chip">project</span>
-          <span class="chip">knowledge</span>
-          <span class="chip">ops</span>
-          <span class="chip">task</span>
-          <span class="chip">overview</span>
+        <div class="compare-shell">
+          <table>
+            <thead>
+              <tr>
+                <th>Typical drifting vault</th>
+                <th>Target state with this package</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td class="muted">Root pages become timeline dumps full of temporary execution history.</td>
+                <td class="muted">Root pages return to navigation, stable boundaries, and topic entrypoints.</td>
+              </tr>
+              <tr>
+                <td class="muted"><code>ops</code> pages become chronological logs of what happened once.</td>
+                <td class="muted"><code>ops</code> pages become reusable symptom / root cause / fix / boundary references.</td>
+              </tr>
+              <tr>
+                <td class="muted">Long-form sources are imported as one big blob and become difficult to revisit.</td>
+                <td class="muted">Sources are split into overview / chapter / topic structures with lineage and better retrieval surfaces.</td>
+              </tr>
+              <tr>
+                <td class="muted">Collaboration context sits in chat, meeting notes, and personal memory.</td>
+                <td class="muted">Working profile, team coordination, and journal workflows create a stable, reviewable collaboration layer.</td>
+              </tr>
+            </tbody>
+          </table>
         </div>
-      </section>
+      </div>
+    </section>
 
-      <aside class="panel stat-card">
-        <div>
-          <div class="kicker">Core package</div>
-          <div class="metric">8</div>
-          <p class="stat-copy">`kit-guide`, `orchestrator`, `ingest`, `maintenance`, `audit`, `working-profile`, `team-coordination`, and `work-journal`.</p>
+    <section class="section">
+      <div class="shell">
+        <div class="section-head">
+          <div>
+            <h2>What’s inside</h2>
+            <p class="sub">The repository keeps the package explicit: 8 public skills, one fixed page-role model, and a small set of repeatable workflows rather than an opaque automation black box.</p>
+          </div>
         </div>
-        <div style="margin-top:24px;">
-          <div class="kicker">Workflow tracks</div>
-          <p class="stat-copy">7 capability tracks, with `kit-guide` + `orchestrator` sharing the onboarding/orchestration role.</p>
+        <div class="grid-4">
+          <article class="section-card">
+            <div class="role-label">onboarding</div>
+            <h3>knowledge-base-kit-guide</h3>
+            <p>Explains installation, profile setup, and which skill to use next.</p>
+          </article>
+          <article class="section-card">
+            <div class="role-label">orchestration</div>
+            <h3>knowledge-base-orchestrator</h3>
+            <p>Provides low-friction onboarding: inspect the current environment, create a skeleton, generate a profile, and route the next step.</p>
+          </article>
+          <article class="section-card">
+            <div class="role-label">ingest</div>
+            <h3>knowledge-base-ingest</h3>
+            <p>Imports long-form markdown with a baseline-first, test-driven, lightweight-harness workflow.</p>
+          </article>
+          <article class="section-card">
+            <div class="role-label">maintenance</div>
+            <h3>knowledge-base-maintenance</h3>
+            <p>Writes durable conclusions back into the right page role while filtering one-off process noise.</p>
+          </article>
+          <article class="section-card">
+            <div class="role-label">audit</div>
+            <h3>knowledge-base-audit</h3>
+            <p>Inspects metadata, dead links, orphan pages, boundary drift, and noise regression.</p>
+          </article>
+          <article class="section-card">
+            <div class="role-label">working profile</div>
+            <h3>knowledge-base-working-profile</h3>
+            <p>Distills collaboration-relevant preferences, heuristics, and boundaries without turning them into a private dossier.</p>
+          </article>
+          <article class="section-card">
+            <div class="role-label">team coordination</div>
+            <h3>knowledge-base-team-coordination</h3>
+            <p>Coordinates shared-project questionnaires, alignment, assignments, and decision distillation.</p>
+          </article>
+          <article class="section-card">
+            <div class="role-label">work journal</div>
+            <h3>work-journal</h3>
+            <p>Captures daily work, meeting notes, and temporary ideas that can later feed durable knowledge.</p>
+          </article>
         </div>
-      </aside>
-    </div>
-  </div>
+      </div>
+    </section>
 
-  <div class="shell section">
-    <h2>30-second outcome</h2>
-    <p class="sub">This repository is for vaults that have drifted into a mix of project logs, unstable navigation, and hard-to-reuse notes.</p>
-    <div class="panel compare">
-      <table>
-        <thead>
-          <tr>
-            <th>Typical drifting vault</th>
-            <th>Target state with this package</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td class="muted">Root pages accumulate temporary execution history.</td>
-            <td class="muted">Root pages return to navigation, stable boundaries, and topic entrypoints.</td>
-          </tr>
-          <tr>
-            <td class="muted"><code>ops</code> pages become chronological logs.</td>
-            <td class="muted"><code>ops</code> pages become reusable symptom / root cause / fix / boundary references.</td>
-          </tr>
-          <tr>
-            <td class="muted"><code>log.md</code> turns into task replay.</td>
-            <td class="muted"><code>log.md</code> stays milestone-only.</td>
-          </tr>
-          <tr>
-            <td class="muted">New teammates or future-you do not know where to start.</td>
-            <td class="muted">Onboarding and specialist skills provide a stable routing path.</td>
-          </tr>
-        </tbody>
-      </table>
-    </div>
-  </div>
+    <section class="section">
+      <div class="shell">
+        <div class="section-head">
+          <div>
+            <h2>One method, several high-density scenarios</h2>
+            <p class="sub">This package is especially strong in environments that are knowledge-dense, frequently updated, collaboration-heavy, and in need of traceability and auditability.</p>
+          </div>
+        </div>
+        <div class="grid-3">
+          <article class="scenario-card">
+            <h3>Medical / pathology / research</h3>
+            <p>Guidelines, textbooks, papers, and case summaries need structure, lineage, and careful update boundaries.</p>
+            <ul>
+              <li>Long-form source ingest</li>
+              <li>Stable method and ops pages</li>
+              <li>Review-friendly collaboration context</li>
+            </ul>
+          </article>
+          <article class="scenario-card">
+            <h3>Enterprise knowledge bases</h3>
+            <p>PRDs, runbooks, delivery docs, and meeting conclusions need reliable navigation and governance instead of ad hoc sprawl.</p>
+            <ul>
+              <li>Maintenance and audit loops</li>
+              <li>Shared-project coordination</li>
+              <li>Cleaner onboarding for teammates</li>
+            </ul>
+          </article>
+          <article class="scenario-card">
+            <h3>Cross-team collaboration</h3>
+            <p>When context is fragmented across chat and temporary docs, shared coordination and journal workflows help prevent repeated re-explanation.</p>
+            <ul>
+              <li>Draft / approved boundaries</li>
+              <li>Traceable meeting and decision context</li>
+              <li>Working-profile hygiene with consent boundaries</li>
+            </ul>
+          </article>
+        </div>
+      </div>
+    </section>
 
-  <div class="shell section">
-    <h2>What’s inside</h2>
-    <p class="sub">The package is meant to be explicit: 8 public skills, one fixed page-role model, and a small number of repeatable workflows.</p>
-    <div class="grid-4">
-      <article class="panel card">
-        <h3>knowledge-base-kit-guide</h3>
-        <p>Explains installation, profile setup, and which skill to use next.</p>
-      </article>
-      <article class="panel card">
-        <h3>knowledge-base-orchestrator</h3>
-        <p>Optional onboarding coordinator: check current environment, create a skeleton, generate a profile, and route the user forward.</p>
-      </article>
-      <article class="panel card">
-        <h3>knowledge-base-ingest</h3>
-        <p>Import long-form markdown with a baseline-first, test-driven, lightweight-harness mindset.</p>
-      </article>
-      <article class="panel card">
-        <h3>knowledge-base-maintenance</h3>
-        <p>Write durable conclusions back into the right page role while filtering process noise.</p>
-      </article>
-      <article class="panel card">
-        <h3>knowledge-base-audit</h3>
-        <p>Inspect metadata, dead links, orphan pages, boundary drift, and noise regression.</p>
-      </article>
-      <article class="panel card">
-        <h3>knowledge-base-working-profile</h3>
-        <p>Distill stable collaboration-relevant preferences, heuristics, and boundaries without turning them into a private dossier.</p>
-      </article>
-      <article class="panel card">
-        <h3>knowledge-base-team-coordination</h3>
-        <p>Coordinate shared-project questionnaires, alignment, assignments, and closeout decision distillation.</p>
-      </article>
-      <article class="panel card">
-        <h3>work-journal</h3>
-        <p>Capture daily work, meeting notes, temporary ideas, and weekly summaries that can feed durable knowledge later.</p>
-      </article>
-    </div>
-  </div>
+    <section class="section">
+      <div class="shell">
+        <div class="section-head">
+          <div>
+            <h2>How it flows</h2>
+            <p class="sub">Start with onboarding, stabilize the profile contract, then move through specialist loops that keep the vault usable as it grows.</p>
+          </div>
+        </div>
+        <div class="flow">
+          <article class="flow-step">
+            <small>01</small>
+            <h3>Install</h3>
+            <p>Copy all 8 skill folders into the skills directory of your AI platform.</p>
+          </article>
+          <article class="flow-step">
+            <small>02</small>
+            <h3>Choose onboarding</h3>
+            <p>Use Orchestrator for a low-friction start or Kit Guide for an explanation-first path.</p>
+          </article>
+          <article class="flow-step">
+            <small>03</small>
+            <h3>Prepare profile</h3>
+            <p>Create or refine <code>vault-profile.md</code> so later workflows have a stable contract.</p>
+          </article>
+          <article class="flow-step">
+            <small>04</small>
+            <h3>Run specialist loops</h3>
+            <p>Move into ingest, maintenance, audit, working-profile, team-coordination, or work-journal as needed.</p>
+          </article>
+          <article class="flow-step">
+            <small>05</small>
+            <h3>Keep it stable</h3>
+            <p>Repeat governance and navigation checks so the vault stays useful instead of drifting again.</p>
+          </article>
+        </div>
+      </div>
+    </section>
 
-  <div class="shell section">
-    <h2>How it flows</h2>
-    <p class="sub">Use Orchestrator when you want the easiest start, Kit Guide when you want to understand the model first, then move into specialist loops.</p>
-    <div class="flow">
-      <article class="panel step"><small>01</small><strong>Install</strong><span>Copy all 8 skill folders into your AI platform’s <code>skills/</code> directory.</span></article>
-      <article class="panel step"><small>02</small><strong>Choose onboarding</strong><span>Use <code>knowledge-base-orchestrator</code> for low-friction setup or <code>knowledge-base-kit-guide</code> for a more explicit explanation-first path.</span></article>
-      <article class="panel step"><small>03</small><strong>Profile</strong><span>Create or refine your <code>vault-profile.md</code> so later specialist skills have a stable contract.</span></article>
-      <article class="panel step"><small>04</small><strong>Specialist loops</strong><span>Move into ingest, maintenance, audit, working-profile, team-coordination, or work-journal depending on the task.</span></article>
-      <article class="panel step"><small>05</small><strong>Stabilize</strong><span>Keep navigation, page roles, and durable knowledge aligned as the vault grows.</span></article>
-    </div>
-  </div>
+    <section class="section">
+      <div class="shell">
+        <div class="section-head">
+          <div>
+            <h2>Fixed page-role model</h2>
+            <p class="sub">The package stays stable because page boundaries are explicit. It does not rely on every contributor improvising structure from scratch.</p>
+          </div>
+        </div>
+        <div class="grid-2">
+          <article class="role-card">
+            <div class="role-label">fixed roles</div>
+            <h3>5 durable page roles</h3>
+            <ul>
+              <li><code>project</code> for navigation, overview, and boundaries</li>
+              <li><code>knowledge</code> for reusable methods and concepts</li>
+              <li><code>ops</code> for troubleshooting and procedures</li>
+              <li><code>task</code> for assignments and in-progress work</li>
+              <li><code>overview</code> for indexes and governance surfaces</li>
+            </ul>
+          </article>
+          <article class="role-card">
+            <div class="role-label">boundary note</div>
+            <h3>Journal is not a sixth role</h3>
+            <p><code>work-journal</code> remains a separate workflow. Journal content is allowed to be more fluid, but durable knowledge should be promoted into the fixed page-role model instead of staying in the journal forever.</p>
+          </article>
+        </div>
+      </div>
+    </section>
 
-  <div class="shell section">
-    <h2>Test-driven ingest example</h2>
-    <p class="sub">A good long-form ingest is not a one-shot import. The initial structure should be treated as a baseline, then improved through testing, regression checks, version comparison, and lightweight harness-style iteration.</p>
-    <div class="grid-3">
-      <article class="panel card">
-        <h3>Baseline first</h3>
-        <p>Import the source into an overview/chapter/topic structure with lineage, TOC, glossary candidates, and related-link suggestions.</p>
-      </article>
-      <article class="panel card">
-        <h3>Compare and refine</h3>
-        <p>Compare split strategies, page roles, and link architecture using real retrieval and maintenance feedback.</p>
-      </article>
-      <article class="panel card">
-        <h3>Refactor safely</h3>
-        <p>Run regression checks on entry pages, lineage, and key links after each revision so the vault becomes cleaner instead of noisier.</p>
-      </article>
-    </div>
-  </div>
+    <section class="section">
+      <div class="shell cta-band">
+        <article class="cta-card primary">
+          <div class="eyebrow">Start with the right surface</div>
+          <h2>Use the HTML page for product overview, the README for method details.</h2>
+          <p class="sub">This landing page is meant to explain the package quickly. The repository README remains the authoritative place for installation, routing, and workflow boundaries.</p>
+          <div class="cta-row">
+            <a class="btn primary" href="https://github.com/zouxy111/wiki-knowledgebase-share-kit/blob/main/START-HERE.md">Go to START-HERE</a>
+            <a class="btn secondary" href="https://github.com/zouxy111/wiki-knowledgebase-share-kit">Open repository</a>
+          </div>
+        </article>
+        <article class="cta-card">
+          <div class="role-label">What to open next</div>
+          <h3>Recommended entrypoints</h3>
+          <ul>
+            <li><a href="https://github.com/zouxy111/wiki-knowledgebase-share-kit/blob/main/START-HERE.md">START-HERE.md</a></li>
+            <li><a href="https://github.com/zouxy111/wiki-knowledgebase-share-kit/blob/main/GLOSSARY.md">GLOSSARY.md</a></li>
+            <li><a href="https://github.com/zouxy111/wiki-knowledgebase-share-kit/blob/main/docs/example-prompts.md">docs/example-prompts.md</a></li>
+            <li><a href="https://github.com/zouxy111/wiki-knowledgebase-share-kit/blob/main/docs/usage-sop.md">docs/usage-sop.md</a></li>
+            <li><a href="https://github.com/zouxy111/wiki-knowledgebase-share-kit/releases/latest">Latest release</a></li>
+          </ul>
+        </article>
+      </div>
+    </section>
+  </main>
 
-  <div class="shell section">
-    <h2>Project preview</h2>
-    <p class="sub">A ready-to-forward preview image is included for release pages, social posts, or repository announcements.</p>
-    <div class="panel preview"><img src="./assets/social-preview.png" alt="Wiki Knowledge Base Share Kit preview" /></div>
-  </div>
-
-  <div class="shell section">
-    <h2>Developers</h2>
-    <p class="sub">Core developers of this repository and share kit.</p>
-    <div class="grid-2">
-      <article class="panel card">
-        <h3>邹星宇</h3>
-        <p>Repository co-developer.</p>
-      </article>
-      <article class="panel card">
-        <h3>杨琦</h3>
-        <p>Repository co-developer.</p>
-      </article>
-    </div>
-  </div>
-
-  <div class="shell footer">
-    Open source under MIT · GitHub repo: <a href="https://github.com/zouxy111/wiki-knowledgebase-share-kit">zouxy111/wiki-knowledgebase-share-kit</a>
+  <div class="shell">
+    <footer class="footer-card">
+      <div>
+        <strong>Wiki Knowledge Base Share Kit</strong>
+        <div class="muted">Open source under MIT · Built by 邹星宇 and 杨琦</div>
+      </div>
+      <div class="footer-links">
+        <a href="https://github.com/zouxy111/wiki-knowledgebase-share-kit">GitHub</a>
+        <a href="https://github.com/zouxy111/wiki-knowledgebase-share-kit/releases">Releases</a>
+        <a href="https://github.com/zouxy111/wiki-knowledgebase-share-kit/issues">Issues</a>
+      </div>
+    </footer>
   </div>
 </body>
 </html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -8,23 +8,26 @@
   <style>
     :root {
       --bg: #07111f;
-      --bg-2: #0a1628;
-      --panel: rgba(11, 23, 40, 0.9);
-      --panel-2: rgba(13, 28, 49, 0.95);
+      --bg-2: #0b182a;
+      --panel: rgba(11, 23, 40, 0.92);
+      --panel-2: rgba(14, 28, 48, 0.96);
       --line: rgba(255,255,255,.10);
       --line-strong: rgba(255,255,255,.18);
       --text: #edf5ff;
-      --muted: #9eb1ca;
+      --muted: #9db0c9;
       --accent: #69d3ff;
-      --accent-2: #8af2d0;
+      --accent-2: #88f1d0;
       --accent-3: #96a6ff;
       --shadow: 0 24px 70px rgba(0,0,0,.30);
+      --shadow-soft: 0 14px 30px rgba(0,0,0,.18);
+      --radius-xl: 28px;
+      --radius-lg: 22px;
+      --radius-md: 18px;
       font-family: Geist, Outfit, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
     }
 
     * { box-sizing: border-box; }
     html { scroll-behavior: smooth; }
-
     body {
       margin: 0;
       color: var(--text);
@@ -39,6 +42,7 @@
     a { color: inherit; text-decoration: none; }
     img { display: block; max-width: 100%; }
     code, pre { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
+    button { font: inherit; }
 
     .shell {
       width: min(1200px, calc(100vw - 32px));
@@ -48,9 +52,9 @@
     .site-header {
       position: sticky;
       top: 0;
-      z-index: 30;
+      z-index: 40;
       backdrop-filter: blur(14px);
-      background: rgba(7, 17, 31, 0.74);
+      background: rgba(7, 17, 31, 0.76);
       border-bottom: 1px solid rgba(255,255,255,.06);
     }
 
@@ -58,7 +62,7 @@
       display: flex;
       align-items: center;
       justify-content: space-between;
-      gap: 20px;
+      gap: 18px;
       padding: 16px 0;
     }
 
@@ -66,6 +70,7 @@
       display: flex;
       align-items: center;
       gap: 12px;
+      min-width: 0;
     }
 
     .brand-mark {
@@ -79,12 +84,14 @@
       background: linear-gradient(135deg, rgba(105,211,255,.24), rgba(138,242,208,.12));
       border: 1px solid rgba(255,255,255,.12);
       color: #dbf6ff;
+      flex: 0 0 auto;
     }
 
     .brand-copy strong {
       display: block;
       font-size: 15px;
       letter-spacing: .02em;
+      white-space: nowrap;
     }
 
     .brand-copy span {
@@ -95,44 +102,84 @@
       text-transform: uppercase;
     }
 
-    .nav-links {
+    .nav-right {
       display: flex;
+      align-items: center;
+      gap: 12px;
       flex-wrap: wrap;
+      justify-content: flex-end;
+    }
+
+    .nav-links,
+    .lang-switch {
+      display: flex;
+      align-items: center;
       gap: 10px;
+      flex-wrap: wrap;
     }
 
     .pill,
     .btn,
-    .chip {
+    .chip,
+    .lang-btn {
       border: 1px solid var(--line);
       border-radius: 999px;
+      transition: border-color .25s ease, background .25s ease, transform .25s ease, color .25s ease;
     }
 
-    .pill {
+    .pill,
+    .lang-btn {
       padding: 10px 14px;
       color: var(--muted);
       background: rgba(255,255,255,.02);
     }
 
     .pill:hover,
-    .btn.secondary:hover {
+    .btn.secondary:hover,
+    .lang-btn:hover {
       border-color: var(--line-strong);
       background: rgba(255,255,255,.05);
+      transform: translateY(-1px);
+    }
+
+    .lang-btn {
+      cursor: pointer;
+      min-width: 54px;
+    }
+
+    .lang-btn.active {
+      color: #07111f;
+      border-color: transparent;
+      background: linear-gradient(135deg, var(--accent), #84a7ff 52%, var(--accent-2));
+      box-shadow: 0 10px 24px rgba(105,211,255,.22);
     }
 
     .hero {
-      padding: 52px 0 26px;
+      padding: 52px 0 28px;
     }
 
     .hero-grid {
       display: grid;
-      grid-template-columns: minmax(0, 1.15fr) minmax(0, .85fr);
+      grid-template-columns: minmax(0, 1.08fr) minmax(0, .92fr);
       gap: 22px;
+      align-items: stretch;
+    }
+
+    .panel,
+    .section-card,
+    .flow-step,
+    .mini-card,
+    .footer-card,
+    .stat-card,
+    .clone-card,
+    .preview-shell {
+      border: 1px solid var(--line);
+      background: rgba(255,255,255,.024);
+      box-shadow: var(--shadow-soft);
     }
 
     .panel {
-      border: 1px solid var(--line);
-      border-radius: 28px;
+      border-radius: var(--radius-xl);
       background:
         linear-gradient(180deg, rgba(255,255,255,.035), rgba(255,255,255,.015)),
         var(--panel);
@@ -147,6 +194,24 @@
     .mini-card,
     .footer-card {
       padding: 28px;
+    }
+
+    .hero-copy {
+      position: relative;
+      isolation: isolate;
+    }
+
+    .hero-copy::after {
+      content: "";
+      position: absolute;
+      inset: auto -80px -120px auto;
+      width: 260px;
+      height: 260px;
+      border-radius: 999px;
+      background: radial-gradient(circle, rgba(105,211,255,.14), transparent 68%);
+      z-index: -1;
+      filter: blur(8px);
+      animation: drift 9s ease-in-out infinite alternate;
     }
 
     .eyebrow {
@@ -169,10 +234,16 @@
 
     h1 {
       margin: 0 0 16px;
-      font-size: clamp(42px, 6vw, 76px);
+      font-size: clamp(40px, 6vw, 74px);
       line-height: .95;
       letter-spacing: -.05em;
       max-width: 10ch;
+    }
+
+    html[lang="zh-CN"] h1 {
+      font-size: clamp(36px, 5.2vw, 64px);
+      line-height: 1.02;
+      max-width: 8.8ch;
     }
 
     h2 {
@@ -193,7 +264,9 @@
     .card-copy,
     .flow-step p,
     .mini-card p,
-    .hero-note {
+    .hero-note,
+    .compare-shell td,
+    .compare-shell th {
       color: var(--muted);
     }
 
@@ -225,6 +298,11 @@
       border-color: transparent;
       background: linear-gradient(135deg, var(--accent), #84a7ff 52%, var(--accent-2));
       box-shadow: 0 14px 36px rgba(105,211,255,.22);
+    }
+
+    .btn.primary:hover {
+      transform: translateY(-2px) scale(1.01);
+      box-shadow: 0 18px 42px rgba(105,211,255,.28);
     }
 
     .chip-row {
@@ -265,16 +343,15 @@
     }
 
     .stats-grid {
-      grid-template-columns: repeat(2, minmax(0,1fr));
+      grid-template-columns: repeat(2, minmax(0, 1fr));
     }
 
     .stat-card,
     .clone-card,
-    .preview-card {
-      border: 1px solid var(--line);
-      border-radius: 22px;
-      background: rgba(255,255,255,.03);
+    .preview-shell {
+      border-radius: var(--radius-lg);
       padding: 18px;
+      background: rgba(255,255,255,.03);
     }
 
     .stat-card strong {
@@ -300,10 +377,8 @@
     }
 
     .preview-shell {
-      border-radius: 22px;
+      padding: 0;
       overflow: hidden;
-      border: 1px solid var(--line);
-      background: rgba(255,255,255,.025);
     }
 
     .preview-topbar {
@@ -349,18 +424,27 @@
 
     .sub { max-width: 68ch; margin: 0; }
 
-    .grid-2 { grid-template-columns: repeat(2, minmax(0,1fr)); }
-    .grid-3 { grid-template-columns: repeat(3, minmax(0,1fr)); }
-    .grid-4 { grid-template-columns: repeat(4, minmax(0,1fr)); }
-    .flow { grid-template-columns: repeat(5, minmax(0,1fr)); }
+    .grid-2 { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+    .grid-3 { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+    .grid-4 { grid-template-columns: repeat(4, minmax(0, 1fr)); }
+    .flow { grid-template-columns: repeat(5, minmax(0, 1fr)); }
 
     .section-card,
     .flow-step,
     .mini-card,
     .footer-card {
-      border: 1px solid var(--line);
       border-radius: 26px;
-      background: rgba(255,255,255,.022);
+    }
+
+    .section-card:hover,
+    .flow-step:hover,
+    .mini-card:hover,
+    .stat-card:hover,
+    .clone-card:hover,
+    .preview-shell:hover {
+      transform: translateY(-4px);
+      border-color: var(--line-strong);
+      box-shadow: 0 18px 38px rgba(0,0,0,.24);
     }
 
     .role-label {
@@ -389,6 +473,7 @@
       border-radius: 26px;
       overflow: hidden;
       background: rgba(255,255,255,.02);
+      box-shadow: var(--shadow-soft);
     }
 
     .compare-shell table {
@@ -403,6 +488,8 @@
       text-align: left;
       vertical-align: top;
     }
+
+    .compare-shell tr:last-child td { border-bottom: none; }
 
     .compare-shell th {
       background: rgba(255,255,255,.03);
@@ -422,82 +509,136 @@
 
     .cta-band {
       display: grid;
-      grid-template-columns: minmax(0,1.15fr) minmax(0,.85fr);
-      gap: 20px;
+      grid-template-columns: minmax(0, 1.35fr) minmax(280px, .65fr);
+      gap: 18px;
+      align-items: stretch;
     }
 
-    .cta-card.primary {
-      background:
-        radial-gradient(circle at top right, rgba(105,211,255,.16), transparent 34%),
-        linear-gradient(135deg, rgba(255,255,255,.05), rgba(255,255,255,.015));
+    .footer-wrap {
+      padding: 0 0 28px;
     }
-
-    .footer-wrap { padding: 8px 0 42px; }
 
     .footer-card {
       display: flex;
-      justify-content: space-between;
       align-items: center;
+      justify-content: space-between;
+      gap: 16px;
       flex-wrap: wrap;
-      gap: 18px;
-      padding: 24px 28px;
+      background: rgba(255,255,255,.022);
     }
 
     .footer-links {
       display: flex;
+      gap: 16px;
       flex-wrap: wrap;
-      gap: 12px;
       color: var(--muted);
     }
 
-    @media (max-width: 1160px) {
-      .hero-grid,
-      .cta-band,
-      .grid-4,
-      .flow { grid-template-columns: 1fr 1fr; }
+    .footer-links a:hover {
+      color: var(--text);
     }
 
-    @media (max-width: 920px) {
+    .reveal {
+      opacity: 0;
+      transform: translateY(24px);
+      transition:
+        opacity .78s cubic-bezier(.22, 1, .36, 1),
+        transform .78s cubic-bezier(.22, 1, .36, 1),
+        border-color .25s ease,
+        box-shadow .25s ease;
+      transition-delay: var(--delay, 0ms);
+      will-change: opacity, transform;
+    }
+
+    .reveal.is-visible {
+      opacity: 1;
+      transform: translateY(0);
+    }
+
+    .reveal.is-instant {
+      transition-duration: 0ms !important;
+      transition-delay: 0ms !important;
+    }
+
+    @keyframes drift {
+      from { transform: translate3d(0, 0, 0) scale(1); }
+      to { transform: translate3d(-16px, -12px, 0) scale(1.08); }
+    }
+
+    @media (max-width: 1100px) {
+      .grid-4 { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+      .flow { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+      .cta-band { grid-template-columns: 1fr; }
+    }
+
+    @media (max-width: 980px) {
+      .nav { align-items: flex-start; }
       .hero-grid,
-      .cta-band,
-      .grid-4,
       .grid-3,
-      .grid-2,
-      .flow,
-      .stats-grid { grid-template-columns: 1fr; }
-      .nav { flex-direction: column; align-items: flex-start; }
+      .grid-2 { grid-template-columns: 1fr; }
+      .stats-grid { grid-template-columns: 1fr 1fr; }
+      h1 { max-width: 12ch; }
+    }
+
+    @media (max-width: 720px) {
+      .shell { width: min(100vw - 20px, 1200px); }
+      .nav,
+      .nav-right { flex-direction: column; align-items: stretch; }
+      .nav-links,
+      .lang-switch { width: 100%; }
+      .pill,
+      .lang-btn,
+      .btn { width: 100%; justify-content: center; }
+      .stats-grid,
+      .grid-4,
+      .flow { grid-template-columns: 1fr; }
       .hero-copy,
       .hero-side,
       .section-card,
       .flow-step,
       .mini-card,
-      .footer-card { padding: 24px; }
+      .footer-card { padding: 22px; }
+      h1 {
+        font-size: clamp(36px, 12vw, 56px);
+        max-width: none;
+      }
+      .compare-shell { overflow-x: auto; }
+      .compare-shell table { min-width: 620px; }
     }
 
-    @media (max-width: 620px) {
-      .shell { width: min(100vw - 24px, 1200px); }
-      .nav-links,
-      .cta-row { width: 100%; }
-      .pill,
-      .btn { width: 100%; justify-content: center; }
-      h1 { max-width: none; }
+    @media (prefers-reduced-motion: reduce) {
+      html { scroll-behavior: auto; }
+      *, *::before, *::after {
+        animation: none !important;
+        transition: none !important;
+      }
+      .reveal {
+        opacity: 1 !important;
+        transform: none !important;
+      }
     }
   </style>
 </head>
 <body>
-  <header class="site-header">
+  <header class="site-header reveal" style="--delay: 30ms;">
     <div class="shell nav">
       <div class="brand">
         <div class="brand-mark">WK</div>
         <div class="brand-copy">
           <strong>Wiki Knowledge Base Share Kit</strong>
-          <span>8-skill knowledge-base package</span>
+          <span data-i18n="brandSubtitle">8-skill knowledge-base package</span>
         </div>
       </div>
-      <div class="nav-links">
-        <a class="pill" href="https://github.com/zouxy111/wiki-knowledgebase-share-kit">GitHub repo</a>
-        <a class="pill" href="https://github.com/zouxy111/wiki-knowledgebase-share-kit/blob/main/START-HERE.md">Start Here</a>
-        <a class="pill" href="https://github.com/zouxy111/wiki-knowledgebase-share-kit/releases/latest">Latest release</a>
+      <div class="nav-right">
+        <div class="nav-links">
+          <a class="pill" href="https://github.com/zouxy111/wiki-knowledgebase-share-kit" data-i18n="navRepo">GitHub repo</a>
+          <a class="pill" href="https://github.com/zouxy111/wiki-knowledgebase-share-kit/blob/main/START-HERE.md" data-i18n="navStart">Start Here</a>
+          <a class="pill" href="https://github.com/zouxy111/wiki-knowledgebase-share-kit/releases/latest" data-i18n="navRelease">Latest release</a>
+        </div>
+        <div class="lang-switch" aria-label="Language switcher">
+          <button type="button" class="lang-btn active" data-lang-toggle="en">EN</button>
+          <button type="button" class="lang-btn" data-lang-toggle="zh">中文</button>
+        </div>
       </div>
     </div>
   </header>
@@ -505,18 +646,16 @@
   <main>
     <section class="hero">
       <div class="shell hero-grid">
-        <article class="panel hero-copy">
-          <div class="eyebrow">Structured knowledge, not note sprawl</div>
-          <h1>Turn your markdown vault into a usable knowledge base.</h1>
-          <p class="lede">
-            A reusable open-source package with 8 installable skills and 7 coordinated workflow tracks.
-            It helps teams and individuals keep a vault navigable, role-stable, maintainable, collaboration-friendly,
-            and auditable instead of letting it drift into scattered notes and process logs.
+        <article class="panel hero-copy reveal" style="--delay: 90ms;">
+          <div class="eyebrow" data-i18n="heroEyebrow">Structured knowledge, not note sprawl</div>
+          <h1 data-i18n="heroTitle">Turn your markdown vault into a usable knowledge base.</h1>
+          <p class="lede" data-i18n="heroLede">
+            A reusable open-source package with 8 installable skills and 7 coordinated workflow tracks. It helps teams and individuals keep a vault navigable, role-stable, maintainable, collaboration-friendly, and auditable instead of letting it drift into scattered notes and process logs.
           </p>
           <div class="cta-row">
-            <a class="btn primary" href="https://github.com/zouxy111/wiki-knowledgebase-share-kit">Get the repository</a>
-            <a class="btn secondary" href="https://github.com/zouxy111/wiki-knowledgebase-share-kit/blob/main/START-HERE.md">Read START-HERE</a>
-            <a class="btn secondary" href="https://github.com/zouxy111/wiki-knowledgebase-share-kit/releases/latest">Browse latest release</a>
+            <a class="btn primary" href="https://github.com/zouxy111/wiki-knowledgebase-share-kit" data-i18n="heroCtaRepo">Get the repository</a>
+            <a class="btn secondary" href="https://github.com/zouxy111/wiki-knowledgebase-share-kit/blob/main/START-HERE.md" data-i18n="heroCtaStart">Read START-HERE</a>
+            <a class="btn secondary" href="https://github.com/zouxy111/wiki-knowledgebase-share-kit/releases/latest" data-i18n="heroCtaRelease">Browse latest release</a>
           </div>
           <div class="chip-row">
             <span class="chip">project</span>
@@ -525,40 +664,40 @@
             <span class="chip">task</span>
             <span class="chip">overview</span>
           </div>
-          <p class="hero-note">
+          <p class="hero-note" data-i18n-html="heroNote">
             The fixed page-role model stays stable. <code>work-journal</code> remains a separate workflow rather than a sixth page role.
           </p>
         </article>
 
-        <aside class="panel hero-side">
+        <aside class="panel hero-side reveal" style="--delay: 150ms;">
           <div class="stats-grid">
-            <div class="stat-card">
-              <span class="muted">Installable skills</span>
+            <div class="stat-card reveal" style="--delay: 180ms;">
+              <span class="muted" data-i18n="statsSkillsLabel">Installable skills</span>
               <strong>8</strong>
-              <span class="muted">kit-guide, orchestrator, ingest, maintenance, audit, working-profile, team-coordination, work-journal</span>
+              <span class="muted" data-i18n="statsSkillsCopy">kit-guide, orchestrator, ingest, maintenance, audit, working-profile, team-coordination, work-journal</span>
             </div>
-            <div class="stat-card">
-              <span class="muted">Workflow tracks</span>
+            <div class="stat-card reveal" style="--delay: 210ms;">
+              <span class="muted" data-i18n="statsTracksLabel">Workflow tracks</span>
               <strong>7</strong>
-              <span class="muted">onboarding, ingest, maintenance, audit, working profile, team coordination, work journal</span>
+              <span class="muted" data-i18n="statsTracksCopy">onboarding, ingest, maintenance, audit, working profile, team coordination, work journal</span>
             </div>
           </div>
 
-          <div class="clone-card">
-            <div class="role-label">Repository</div>
-            <h3>Clone it directly</h3>
-            <p class="muted">If you want the actual repository instead of only browsing the landing page, start here.</p>
+          <div class="clone-card reveal" style="--delay: 240ms;">
+            <div class="role-label" data-i18n="cloneLabel">Repository</div>
+            <h3 data-i18n="cloneTitle">Clone it directly</h3>
+            <p class="muted" data-i18n="cloneCopy">If you want the actual repository instead of only browsing the landing page, start here.</p>
             <pre><code>git clone https://github.com/zouxy111/wiki-knowledgebase-share-kit.git</code></pre>
           </div>
 
-          <div class="preview-shell">
+          <div class="preview-shell reveal" style="--delay: 270ms;">
             <div class="preview-topbar">
               <span class="dot"></span>
               <span class="dot"></span>
               <span class="dot"></span>
-              <span>Landing page preview</span>
+              <span data-i18n="previewLabel">Landing page preview</span>
             </div>
-            <img src="./assets/social-preview.png" alt="Wiki Knowledge Base Share Kit preview" />
+            <img src="./assets/social-preview.png" alt="Wiki Knowledge Base Share Kit preview" data-i18n-alt="previewAlt" />
           </div>
         </aside>
       </div>
@@ -566,36 +705,36 @@
 
     <section class="section">
       <div class="shell">
-        <div class="section-head">
+        <div class="section-head reveal" style="--delay: 40ms;">
           <div>
-            <h2>Why this package exists</h2>
-            <p class="sub">The point is not to write more notes. The point is to stop a vault from decaying into a maze of folders, mixed page roles, broken navigation, and hard-to-reuse knowledge.</p>
+            <h2 data-i18n="whyTitle">Why this package exists</h2>
+            <p class="sub" data-i18n="whySub">The point is not to write more notes. The point is to stop a vault from decaying into a maze of folders, mixed page roles, broken navigation, and hard-to-reuse knowledge.</p>
           </div>
         </div>
-        <div class="compare-shell">
+        <div class="compare-shell reveal" style="--delay: 90ms;">
           <table>
             <thead>
               <tr>
-                <th>Typical drifting vault</th>
-                <th>Target state with this package</th>
+                <th data-i18n="whyTableLeft">Typical drifting vault</th>
+                <th data-i18n="whyTableRight">Target state with this package</th>
               </tr>
             </thead>
             <tbody>
               <tr>
-                <td class="muted">Root pages become timeline dumps full of temporary execution history.</td>
-                <td class="muted">Root pages return to navigation, stable boundaries, and topic entrypoints.</td>
+                <td data-i18n="whyRow1Left">Root pages become timeline dumps full of temporary execution history.</td>
+                <td data-i18n="whyRow1Right">Root pages return to navigation, stable boundaries, and topic entrypoints.</td>
               </tr>
               <tr>
-                <td class="muted"><code>ops</code> pages become chronological logs of what happened once.</td>
-                <td class="muted"><code>ops</code> pages become reusable symptom / root cause / fix / boundary references.</td>
+                <td data-i18n-html="whyRow2Left"><code>ops</code> pages become chronological logs of what happened once.</td>
+                <td data-i18n-html="whyRow2Right"><code>ops</code> pages become reusable symptom / root cause / fix / boundary references.</td>
               </tr>
               <tr>
-                <td class="muted">Long-form sources are imported as one big blob and become difficult to revisit.</td>
-                <td class="muted">Sources are split into overview / chapter / topic structures with lineage and retrieval surfaces.</td>
+                <td data-i18n="whyRow3Left">Long-form sources are imported as one big blob and become difficult to revisit.</td>
+                <td data-i18n="whyRow3Right">Sources are split into overview / chapter / topic structures with lineage and retrieval surfaces.</td>
               </tr>
               <tr>
-                <td class="muted">Collaboration context sits in chat, meeting notes, and personal memory.</td>
-                <td class="muted">Working profile, team coordination, and journal workflows create a stable, reviewable collaboration layer.</td>
+                <td data-i18n="whyRow4Left">Collaboration context sits in chat, meeting notes, and personal memory.</td>
+                <td data-i18n="whyRow4Right">Working profile, team coordination, and journal workflows create a stable, reviewable collaboration layer.</td>
               </tr>
             </tbody>
           </table>
@@ -605,52 +744,52 @@
 
     <section class="section">
       <div class="shell">
-        <div class="section-head">
+        <div class="section-head reveal" style="--delay: 40ms;">
           <div>
-            <h2>What’s inside</h2>
-            <p class="sub">The repository keeps the package explicit: 8 public skills, one fixed page-role model, and a small set of repeatable workflows rather than a black-box automation promise.</p>
+            <h2 data-i18n="insideTitle">What’s inside</h2>
+            <p class="sub" data-i18n="insideSub">The repository keeps the package explicit: 8 public skills, one fixed page-role model, and a small set of repeatable workflows rather than a black-box automation promise.</p>
           </div>
         </div>
         <div class="grid-4">
-          <article class="section-card">
-            <div class="role-label">onboarding</div>
+          <article class="section-card reveal" style="--delay: 70ms;">
+            <div class="role-label" data-i18n="skill1Label">onboarding</div>
             <h3>knowledge-base-kit-guide</h3>
-            <p class="card-copy">Explains installation, profile setup, and which skill to use next.</p>
+            <p class="card-copy" data-i18n="skill1Copy">Explains installation, profile setup, and which skill to use next.</p>
           </article>
-          <article class="section-card">
-            <div class="role-label">orchestration</div>
+          <article class="section-card reveal" style="--delay: 100ms;">
+            <div class="role-label" data-i18n="skill2Label">orchestration</div>
             <h3>knowledge-base-orchestrator</h3>
-            <p class="card-copy">Provides low-friction onboarding: inspect the environment, create a skeleton, generate a profile, and route the next step.</p>
+            <p class="card-copy" data-i18n="skill2Copy">Provides low-friction onboarding: inspect the environment, create a skeleton, generate a profile, and route the next step.</p>
           </article>
-          <article class="section-card">
-            <div class="role-label">ingest</div>
+          <article class="section-card reveal" style="--delay: 130ms;">
+            <div class="role-label" data-i18n="skill3Label">ingest</div>
             <h3>knowledge-base-ingest</h3>
-            <p class="card-copy">Imports long-form markdown with a baseline-first, test-driven, lightweight-harness workflow.</p>
+            <p class="card-copy" data-i18n="skill3Copy">Imports long-form markdown with a baseline-first, test-driven, lightweight-harness workflow.</p>
           </article>
-          <article class="section-card">
-            <div class="role-label">maintenance</div>
+          <article class="section-card reveal" style="--delay: 160ms;">
+            <div class="role-label" data-i18n="skill4Label">maintenance</div>
             <h3>knowledge-base-maintenance</h3>
-            <p class="card-copy">Writes durable conclusions back into the right page role while filtering one-off process noise.</p>
+            <p class="card-copy" data-i18n="skill4Copy">Writes durable conclusions back into the right page role while filtering one-off process noise.</p>
           </article>
-          <article class="section-card">
-            <div class="role-label">audit</div>
+          <article class="section-card reveal" style="--delay: 190ms;">
+            <div class="role-label" data-i18n="skill5Label">audit</div>
             <h3>knowledge-base-audit</h3>
-            <p class="card-copy">Inspects metadata, dead links, orphan pages, boundary drift, and noise regression.</p>
+            <p class="card-copy" data-i18n="skill5Copy">Inspects metadata, dead links, orphan pages, boundary drift, and noise regression.</p>
           </article>
-          <article class="section-card">
-            <div class="role-label">working profile</div>
+          <article class="section-card reveal" style="--delay: 220ms;">
+            <div class="role-label" data-i18n="skill6Label">working profile</div>
             <h3>knowledge-base-working-profile</h3>
-            <p class="card-copy">Distills collaboration-relevant preferences, heuristics, and boundaries without turning them into a private dossier.</p>
+            <p class="card-copy" data-i18n="skill6Copy">Distills collaboration-relevant preferences, heuristics, and boundaries without turning them into a private dossier.</p>
           </article>
-          <article class="section-card">
-            <div class="role-label">team coordination</div>
+          <article class="section-card reveal" style="--delay: 250ms;">
+            <div class="role-label" data-i18n="skill7Label">team coordination</div>
             <h3>knowledge-base-team-coordination</h3>
-            <p class="card-copy">Coordinates questionnaires, alignment, assignments, and closeout decision distillation.</p>
+            <p class="card-copy" data-i18n="skill7Copy">Coordinates questionnaires, alignment, assignments, and closeout decision distillation.</p>
           </article>
-          <article class="section-card">
-            <div class="role-label">work journal</div>
+          <article class="section-card reveal" style="--delay: 280ms;">
+            <div class="role-label" data-i18n="skill8Label">work journal</div>
             <h3>work-journal</h3>
-            <p class="card-copy">Captures daily work, meeting notes, and temporary ideas that can later feed durable knowledge.</p>
+            <p class="card-copy" data-i18n="skill8Copy">Captures daily work, meeting notes, and temporary ideas that can later feed durable knowledge.</p>
           </article>
         </div>
       </div>
@@ -658,35 +797,35 @@
 
     <section class="section">
       <div class="shell">
-        <div class="section-head">
+        <div class="section-head reveal" style="--delay: 40ms;">
           <div>
-            <h2>One method, several high-density scenarios</h2>
-            <p class="sub">This package is strongest in environments that are knowledge-dense, frequently updated, collaboration-heavy, and in need of traceability and auditability.</p>
+            <h2 data-i18n="scenariosTitle">One method, several high-density scenarios</h2>
+            <p class="sub" data-i18n="scenariosSub">This package is strongest in environments that are knowledge-dense, frequently updated, collaboration-heavy, and in need of traceability and auditability.</p>
           </div>
         </div>
         <div class="grid-3">
-          <article class="mini-card">
-            <h3>Medical / pathology / research</h3>
-            <p>Guidelines, textbooks, papers, and case summaries need structure, lineage, and careful update boundaries.</p>
-            <ul>
+          <article class="mini-card reveal" style="--delay: 70ms;">
+            <h3 data-i18n="scenario1Title">Medical / pathology / research</h3>
+            <p data-i18n="scenario1Copy">Guidelines, textbooks, papers, and case summaries need structure, lineage, and careful update boundaries.</p>
+            <ul data-i18n-html="scenario1List">
               <li>Long-form source ingest</li>
               <li>Stable knowledge and ops pages</li>
               <li>Review-friendly collaboration context</li>
             </ul>
           </article>
-          <article class="mini-card">
-            <h3>Enterprise knowledge bases</h3>
-            <p>PRDs, runbooks, delivery docs, and meeting conclusions need reliable navigation and governance instead of ad hoc sprawl.</p>
-            <ul>
+          <article class="mini-card reveal" style="--delay: 100ms;">
+            <h3 data-i18n="scenario2Title">Enterprise knowledge bases</h3>
+            <p data-i18n="scenario2Copy">PRDs, runbooks, delivery docs, and meeting conclusions need reliable navigation and governance instead of ad hoc sprawl.</p>
+            <ul data-i18n-html="scenario2List">
               <li>Maintenance and audit loops</li>
               <li>Shared-project coordination</li>
               <li>Cleaner onboarding for teammates</li>
             </ul>
           </article>
-          <article class="mini-card">
-            <h3>Cross-team collaboration</h3>
-            <p>When context is fragmented across chat and temporary docs, shared coordination and journal workflows reduce repeated re-explanation.</p>
-            <ul>
+          <article class="mini-card reveal" style="--delay: 130ms;">
+            <h3 data-i18n="scenario3Title">Cross-team collaboration</h3>
+            <p data-i18n="scenario3Copy">When context is fragmented across chat and temporary docs, shared coordination and journal workflows reduce repeated re-explanation.</p>
+            <ul data-i18n-html="scenario3List">
               <li>Draft / approved boundaries</li>
               <li>Traceable meeting and decision context</li>
               <li>Working-profile hygiene with consent boundaries</li>
@@ -698,37 +837,37 @@
 
     <section class="section">
       <div class="shell">
-        <div class="section-head">
+        <div class="section-head reveal" style="--delay: 40ms;">
           <div>
-            <h2>How it flows</h2>
-            <p class="sub">Start with onboarding, stabilize the profile contract, then move through specialist loops that keep the vault usable as it grows.</p>
+            <h2 data-i18n="flowTitle">How it flows</h2>
+            <p class="sub" data-i18n="flowSub">Start with onboarding, stabilize the profile contract, then move through specialist loops that keep the vault usable as it grows.</p>
           </div>
         </div>
         <div class="flow">
-          <article class="flow-step">
+          <article class="flow-step reveal" style="--delay: 70ms;">
             <small>01</small>
-            <h3>Install</h3>
-            <p>Copy all 8 skill folders into the skills directory of your AI platform.</p>
+            <h3 data-i18n="flow1Title">Install</h3>
+            <p data-i18n="flow1Copy">Copy all 8 skill folders into the skills directory of your AI platform.</p>
           </article>
-          <article class="flow-step">
+          <article class="flow-step reveal" style="--delay: 100ms;">
             <small>02</small>
-            <h3>Choose onboarding</h3>
-            <p>Use Orchestrator for a low-friction start or Kit Guide for an explanation-first path.</p>
+            <h3 data-i18n="flow2Title">Choose onboarding</h3>
+            <p data-i18n="flow2Copy">Use Orchestrator for a low-friction start or Kit Guide for an explanation-first path.</p>
           </article>
-          <article class="flow-step">
+          <article class="flow-step reveal" style="--delay: 130ms;">
             <small>03</small>
-            <h3>Prepare profile</h3>
-            <p>Create or refine <code>vault-profile.md</code> so later workflows have a stable contract.</p>
+            <h3 data-i18n="flow3Title">Prepare profile</h3>
+            <p data-i18n-html="flow3Copy">Create or refine <code>vault-profile.md</code> so later workflows have a stable contract.</p>
           </article>
-          <article class="flow-step">
+          <article class="flow-step reveal" style="--delay: 160ms;">
             <small>04</small>
-            <h3>Run specialist loops</h3>
-            <p>Move into ingest, maintenance, audit, working-profile, team-coordination, or work-journal as needed.</p>
+            <h3 data-i18n="flow4Title">Run specialist loops</h3>
+            <p data-i18n="flow4Copy">Move into ingest, maintenance, audit, working-profile, team-coordination, or work-journal as needed.</p>
           </article>
-          <article class="flow-step">
+          <article class="flow-step reveal" style="--delay: 190ms;">
             <small>05</small>
-            <h3>Keep it stable</h3>
-            <p>Repeat governance and navigation checks so the vault stays useful instead of drifting again.</p>
+            <h3 data-i18n="flow5Title">Keep it stable</h3>
+            <p data-i18n="flow5Copy">Repeat governance and navigation checks so the vault stays useful instead of drifting again.</p>
           </article>
         </div>
       </div>
@@ -736,10 +875,10 @@
 
     <section class="section">
       <div class="shell grid-2">
-        <article class="mini-card">
-          <div class="role-label">fixed model</div>
-          <h3>5 durable page roles</h3>
-          <ul>
+        <article class="mini-card reveal" style="--delay: 70ms;">
+          <div class="role-label" data-i18n="rolesLabel">fixed model</div>
+          <h3 data-i18n="rolesTitle">5 durable page roles</h3>
+          <ul data-i18n-html="rolesList">
             <li><code>project</code> for navigation, overview, and boundaries</li>
             <li><code>knowledge</code> for reusable methods and concepts</li>
             <li><code>ops</code> for troubleshooting and procedures</li>
@@ -747,29 +886,29 @@
             <li><code>overview</code> for indexes and governance surfaces</li>
           </ul>
         </article>
-        <article class="mini-card">
-          <div class="role-label">boundary note</div>
-          <h3>Journal is not a sixth role</h3>
-          <p>Journal content can be more fluid, but durable knowledge should be promoted into the fixed page-role model instead of remaining in the journal forever.</p>
+        <article class="mini-card reveal" style="--delay: 100ms;">
+          <div class="role-label" data-i18n="journalLabel">boundary note</div>
+          <h3 data-i18n="journalTitle">Journal is not a sixth role</h3>
+          <p data-i18n="journalCopy">Journal content can be more fluid, but durable knowledge should be promoted into the fixed page-role model instead of remaining in the journal forever.</p>
         </article>
       </div>
     </section>
 
     <section class="section">
       <div class="shell cta-band">
-        <article class="section-card">
-          <div class="eyebrow">Get started from the right surface</div>
-          <h2>Use the HTML page for overview, the repository for the actual package.</h2>
-          <p class="sub">This landing page is designed for quick understanding. The GitHub repository remains the authoritative surface for installation, routing, documentation, and release artifacts.</p>
+        <article class="section-card reveal" style="--delay: 70ms;">
+          <div class="eyebrow" data-i18n="ctaEyebrow">Get started from the right surface</div>
+          <h2 data-i18n="ctaTitle">Use the HTML page for overview, the repository for the actual package.</h2>
+          <p class="sub" data-i18n="ctaSub">This landing page is designed for quick understanding. The GitHub repository remains the authoritative surface for installation, routing, documentation, and release artifacts.</p>
           <div class="cta-row">
-            <a class="btn primary" href="https://github.com/zouxy111/wiki-knowledgebase-share-kit">Open GitHub repository</a>
-            <a class="btn secondary" href="https://github.com/zouxy111/wiki-knowledgebase-share-kit/blob/main/START-HERE.md">Go to START-HERE</a>
+            <a class="btn primary" href="https://github.com/zouxy111/wiki-knowledgebase-share-kit" data-i18n="ctaRepo">Open GitHub repository</a>
+            <a class="btn secondary" href="https://github.com/zouxy111/wiki-knowledgebase-share-kit/blob/main/START-HERE.md" data-i18n="ctaStart">Go to START-HERE</a>
           </div>
         </article>
-        <article class="mini-card">
-          <div class="role-label">Next surfaces</div>
-          <h3>Open these next</h3>
-          <ul>
+        <article class="mini-card reveal" style="--delay: 100ms;">
+          <div class="role-label" data-i18n="nextLabel">Next surfaces</div>
+          <h3 data-i18n="nextTitle">Open these next</h3>
+          <ul data-i18n-html="nextList">
             <li><a href="https://github.com/zouxy111/wiki-knowledgebase-share-kit/blob/main/START-HERE.md">START-HERE.md</a></li>
             <li><a href="https://github.com/zouxy111/wiki-knowledgebase-share-kit/blob/main/GLOSSARY.md">GLOSSARY.md</a></li>
             <li><a href="https://github.com/zouxy111/wiki-knowledgebase-share-kit/blob/main/docs/example-prompts.md">docs/example-prompts.md</a></li>
@@ -782,17 +921,294 @@
   </main>
 
   <div class="shell footer-wrap">
-    <footer class="footer-card">
+    <footer class="footer-card reveal" style="--delay: 60ms;">
       <div>
         <strong>Wiki Knowledge Base Share Kit</strong>
-        <div class="muted">Open source under MIT · Built by 邹星宇 and 杨琦</div>
+        <div class="muted" data-i18n="footerCopy">Open source under MIT · Built by 邹星宇 and 杨琦</div>
       </div>
       <div class="footer-links">
-        <a href="https://github.com/zouxy111/wiki-knowledgebase-share-kit">GitHub repo</a>
-        <a href="https://github.com/zouxy111/wiki-knowledgebase-share-kit/releases">Releases</a>
-        <a href="https://github.com/zouxy111/wiki-knowledgebase-share-kit/issues">Issues</a>
+        <a href="https://github.com/zouxy111/wiki-knowledgebase-share-kit" data-i18n="footerRepo">GitHub repo</a>
+        <a href="https://github.com/zouxy111/wiki-knowledgebase-share-kit/releases" data-i18n="footerReleases">Releases</a>
+        <a href="https://github.com/zouxy111/wiki-knowledgebase-share-kit/issues" data-i18n="footerIssues">Issues</a>
       </div>
     </footer>
   </div>
+
+  <script>
+    const translations = {
+      en: {
+        pageTitle: "Wiki Knowledge Base Share Kit",
+        pageDescription: "An 8-skill knowledge-base package for markdown, wiki, and Obsidian-style vaults.",
+        brandSubtitle: "8-skill knowledge-base package",
+        navRepo: "GitHub repo",
+        navStart: "Start Here",
+        navRelease: "Latest release",
+        heroEyebrow: "Structured knowledge, not note sprawl",
+        heroTitle: "Turn your markdown vault into a usable knowledge base.",
+        heroLede: "A reusable open-source package with 8 installable skills and 7 coordinated workflow tracks. It helps teams and individuals keep a vault navigable, role-stable, maintainable, collaboration-friendly, and auditable instead of letting it drift into scattered notes and process logs.",
+        heroCtaRepo: "Get the repository",
+        heroCtaStart: "Read START-HERE",
+        heroCtaRelease: "Browse latest release",
+        heroNote: "The fixed page-role model stays stable. <code>work-journal</code> remains a separate workflow rather than a sixth page role.",
+        statsSkillsLabel: "Installable skills",
+        statsSkillsCopy: "kit-guide, orchestrator, ingest, maintenance, audit, working-profile, team-coordination, work-journal",
+        statsTracksLabel: "Workflow tracks",
+        statsTracksCopy: "onboarding, ingest, maintenance, audit, working profile, team coordination, work journal",
+        cloneLabel: "Repository",
+        cloneTitle: "Clone it directly",
+        cloneCopy: "If you want the actual repository instead of only browsing the landing page, start here.",
+        previewLabel: "Landing page preview",
+        previewAlt: "Wiki Knowledge Base Share Kit preview",
+        whyTitle: "Why this package exists",
+        whySub: "The point is not to write more notes. The point is to stop a vault from decaying into a maze of folders, mixed page roles, broken navigation, and hard-to-reuse knowledge.",
+        whyTableLeft: "Typical drifting vault",
+        whyTableRight: "Target state with this package",
+        whyRow1Left: "Root pages become timeline dumps full of temporary execution history.",
+        whyRow1Right: "Root pages return to navigation, stable boundaries, and topic entrypoints.",
+        whyRow2Left: "<code>ops</code> pages become chronological logs of what happened once.",
+        whyRow2Right: "<code>ops</code> pages become reusable symptom / root cause / fix / boundary references.",
+        whyRow3Left: "Long-form sources are imported as one big blob and become difficult to revisit.",
+        whyRow3Right: "Sources are split into overview / chapter / topic structures with lineage and retrieval surfaces.",
+        whyRow4Left: "Collaboration context sits in chat, meeting notes, and personal memory.",
+        whyRow4Right: "Working profile, team coordination, and journal workflows create a stable, reviewable collaboration layer.",
+        insideTitle: "What’s inside",
+        insideSub: "The repository keeps the package explicit: 8 public skills, one fixed page-role model, and a small set of repeatable workflows rather than a black-box automation promise.",
+        skill1Label: "onboarding",
+        skill1Copy: "Explains installation, profile setup, and which skill to use next.",
+        skill2Label: "orchestration",
+        skill2Copy: "Provides low-friction onboarding: inspect the environment, create a skeleton, generate a profile, and route the next step.",
+        skill3Label: "ingest",
+        skill3Copy: "Imports long-form markdown with a baseline-first, test-driven, lightweight-harness workflow.",
+        skill4Label: "maintenance",
+        skill4Copy: "Writes durable conclusions back into the right page role while filtering one-off process noise.",
+        skill5Label: "audit",
+        skill5Copy: "Inspects metadata, dead links, orphan pages, boundary drift, and noise regression.",
+        skill6Label: "working profile",
+        skill6Copy: "Distills collaboration-relevant preferences, heuristics, and boundaries without turning them into a private dossier.",
+        skill7Label: "team coordination",
+        skill7Copy: "Coordinates questionnaires, alignment, assignments, and closeout decision distillation.",
+        skill8Label: "work journal",
+        skill8Copy: "Captures daily work, meeting notes, and temporary ideas that can later feed durable knowledge.",
+        scenariosTitle: "One method, several high-density scenarios",
+        scenariosSub: "This package is strongest in environments that are knowledge-dense, frequently updated, collaboration-heavy, and in need of traceability and auditability.",
+        scenario1Title: "Medical / pathology / research",
+        scenario1Copy: "Guidelines, textbooks, papers, and case summaries need structure, lineage, and careful update boundaries.",
+        scenario1List: "<li>Long-form source ingest</li><li>Stable knowledge and ops pages</li><li>Review-friendly collaboration context</li>",
+        scenario2Title: "Enterprise knowledge bases",
+        scenario2Copy: "PRDs, runbooks, delivery docs, and meeting conclusions need reliable navigation and governance instead of ad hoc sprawl.",
+        scenario2List: "<li>Maintenance and audit loops</li><li>Shared-project coordination</li><li>Cleaner onboarding for teammates</li>",
+        scenario3Title: "Cross-team collaboration",
+        scenario3Copy: "When context is fragmented across chat and temporary docs, shared coordination and journal workflows reduce repeated re-explanation.",
+        scenario3List: "<li>Draft / approved boundaries</li><li>Traceable meeting and decision context</li><li>Working-profile hygiene with consent boundaries</li>",
+        flowTitle: "How it flows",
+        flowSub: "Start with onboarding, stabilize the profile contract, then move through specialist loops that keep the vault usable as it grows.",
+        flow1Title: "Install",
+        flow1Copy: "Copy all 8 skill folders into the skills directory of your AI platform.",
+        flow2Title: "Choose onboarding",
+        flow2Copy: "Use Orchestrator for a low-friction start or Kit Guide for an explanation-first path.",
+        flow3Title: "Prepare profile",
+        flow3Copy: "Create or refine <code>vault-profile.md</code> so later workflows have a stable contract.",
+        flow4Title: "Run specialist loops",
+        flow4Copy: "Move into ingest, maintenance, audit, working-profile, team-coordination, or work-journal as needed.",
+        flow5Title: "Keep it stable",
+        flow5Copy: "Repeat governance and navigation checks so the vault stays useful instead of drifting again.",
+        rolesLabel: "fixed model",
+        rolesTitle: "5 durable page roles",
+        rolesList: "<li><code>project</code> for navigation, overview, and boundaries</li><li><code>knowledge</code> for reusable methods and concepts</li><li><code>ops</code> for troubleshooting and procedures</li><li><code>task</code> for assignments and in-progress work</li><li><code>overview</code> for indexes and governance surfaces</li>",
+        journalLabel: "boundary note",
+        journalTitle: "Journal is not a sixth role",
+        journalCopy: "Journal content can be more fluid, but durable knowledge should be promoted into the fixed page-role model instead of remaining in the journal forever.",
+        ctaEyebrow: "Get started from the right surface",
+        ctaTitle: "Use the HTML page for overview, the repository for the actual package.",
+        ctaSub: "This landing page is designed for quick understanding. The GitHub repository remains the authoritative surface for installation, routing, documentation, and release artifacts.",
+        ctaRepo: "Open GitHub repository",
+        ctaStart: "Go to START-HERE",
+        nextLabel: "Next surfaces",
+        nextTitle: "Open these next",
+        nextList: "<li><a href=\"https://github.com/zouxy111/wiki-knowledgebase-share-kit/blob/main/START-HERE.md\">START-HERE.md</a></li><li><a href=\"https://github.com/zouxy111/wiki-knowledgebase-share-kit/blob/main/GLOSSARY.md\">GLOSSARY.md</a></li><li><a href=\"https://github.com/zouxy111/wiki-knowledgebase-share-kit/blob/main/docs/example-prompts.md\">docs/example-prompts.md</a></li><li><a href=\"https://github.com/zouxy111/wiki-knowledgebase-share-kit/releases/latest\">Latest release</a></li><li><a href=\"https://github.com/zouxy111/wiki-knowledgebase-share-kit/issues\">Issues</a></li>",
+        footerCopy: "Open source under MIT · Built by 邹星宇 and 杨琦",
+        footerRepo: "GitHub repo",
+        footerReleases: "Releases",
+        footerIssues: "Issues"
+      },
+      zh: {
+        pageTitle: "Wiki Knowledge Base Share Kit｜知识库分享包",
+        pageDescription: "一个面向 markdown、wiki 和 Obsidian 风格 vault 的 8-skill 知识库工作包。",
+        brandSubtitle: "8-skill 知识库工作包",
+        navRepo: "GitHub 仓库",
+        navStart: "快速开始",
+        navRelease: "最新版本",
+        heroEyebrow: "结构化知识，而不是笔记蔓延",
+        heroTitle: "把 markdown vault 变成真正可用的知识库。",
+        heroLede: "这是一个可复用的开源工作包，包含 8 个可安装 skills 和 7 条协同工作流。它帮助个人和团队让 vault 保持可导航、角色稳定、可维护、便于协作、可审计，而不是继续漂成零散笔记和过程流水账。",
+        heroCtaRepo: "获取仓库",
+        heroCtaStart: "阅读 START-HERE",
+        heroCtaRelease: "查看最新版本",
+        heroNote: "固定的 page-role model 会保持稳定。<code>work-journal</code> 是独立工作流，不是第六种页面角色。",
+        statsSkillsLabel: "可安装 skills",
+        statsSkillsCopy: "kit-guide、orchestrator、ingest、maintenance、audit、working-profile、team-coordination、work-journal",
+        statsTracksLabel: "工作流轨道",
+        statsTracksCopy: "onboarding、ingest、maintenance、audit、working profile、team coordination、work journal",
+        cloneLabel: "仓库入口",
+        cloneTitle: "直接拉仓库",
+        cloneCopy: "如果你想拿到真正的仓库，而不只是浏览这个落地页，直接从这里开始。",
+        previewLabel: "首页预览",
+        previewAlt: "Wiki Knowledge Base Share Kit 预览图",
+        whyTitle: "为什么需要这个包",
+        whySub: "重点不是写更多笔记，而是阻止 vault 继续退化成文件夹迷宫、页面角色混杂、导航断裂、知识难以复用的状态。",
+        whyTableLeft: "常见的漂移型 vault",
+        whyTableRight: "使用这个包后的目标状态",
+        whyRow1Left: "根页面逐渐变成堆满临时执行历史的时间线垃圾场。",
+        whyRow1Right: "根页面重新回到导航、稳定边界和主题入口的职责。",
+        whyRow2Left: "<code>ops</code> 页面慢慢变成一次性过程流水账。",
+        whyRow2Right: "<code>ops</code> 页面沉淀为可复用的现象 / 根因 / 修复 / 边界参考。",
+        whyRow3Left: "长文档导入后只是一个大块文本，之后很难再回查。",
+        whyRow3Right: "知识源会被拆成 overview / chapter / topic 结构，并带上来源链和检索入口。",
+        whyRow4Left: "协作上下文散落在聊天、会议记录和个人脑内记忆里。",
+        whyRow4Right: "working profile、team coordination 和 journal 工作流会形成稳定、可复查的协作层。",
+        insideTitle: "这个包里有什么",
+        insideSub: "仓库公开地展示了包的组成：8 个 public skills、1 套固定 page-role model，以及几条可重复工作流，而不是把能力包装成黑盒自动化承诺。",
+        skill1Label: "引导",
+        skill1Copy: "解释安装方式、profile 配置，以及下一步应该用哪个 skill。",
+        skill2Label: "总控引导",
+        skill2Copy: "提供低门槛 onboarding：检查环境、创建骨架、生成 profile，并给出下一步路由。",
+        skill3Label: "导入",
+        skill3Copy: "用 baseline-first、测试驱动、轻量 harness 的方式导入长篇 markdown。",
+        skill4Label: "维护",
+        skill4Copy: "把真正耐久的结论写回正确页面角色，同时过滤一次性过程噪音。",
+        skill5Label: "审计",
+        skill5Copy: "检查 metadata、死链、孤儿页、边界漂移和噪音回归。",
+        skill6Label: "工作画像",
+        skill6Copy: "提炼与协作有关的偏好、启发式和边界，但不会把它做成私人档案。",
+        skill7Label: "团队协同",
+        skill7Copy: "支持问卷、对齐、分工以及收尾时的决策沉淀。",
+        skill8Label: "工作日志",
+        skill8Copy: "记录日常工作、会议笔记和临时想法，后续再把有价值的部分提升成耐久知识。",
+        scenariosTitle: "一种方法，适配多种高密度场景",
+        scenariosSub: "这个包最适合知识密度高、变化频繁、多人协作且需要可追溯与可审计性的环境。",
+        scenario1Title: "医疗 / 病理 / 研究",
+        scenario1Copy: "规范、教材、论文和案例总结需要清晰结构、来源链和谨慎的更新边界。",
+        scenario1List: "<li>长文档知识源导入</li><li>稳定的 knowledge / ops 页面</li><li>更适合复审的协作上下文</li>",
+        scenario2Title: "企业知识库",
+        scenario2Copy: "PRD、runbook、交付文档和会议结论需要可靠的导航与治理，而不是临时拼凑式堆积。",
+        scenario2List: "<li>maintenance 和 audit 循环</li><li>共享项目协同</li><li>更干净的团队 onboarding</li>",
+        scenario3Title: "跨团队协作",
+        scenario3Copy: "当上下文散落在聊天和临时文档里时，shared coordination 和 journal 工作流能减少反复解释。",
+        scenario3List: "<li>草稿 / 定稿边界更清晰</li><li>会议和决策上下文可追溯</li><li>带 consent 边界的 working-profile 卫生</li>",
+        flowTitle: "它怎么运转",
+        flowSub: "先完成 onboarding，稳定 profile 合约，再进入各条 specialist loops，让 vault 在持续增长时仍然保持可用。",
+        flow1Title: "安装",
+        flow1Copy: "把 8 个 skill 文件夹复制到你的 AI 平台 skills 目录。",
+        flow2Title: "选择 onboarding 入口",
+        flow2Copy: "想低门槛启动就用 Orchestrator；想先理解方法再上手就用 Kit Guide。",
+        flow3Title: "准备 profile",
+        flow3Copy: "创建或完善 <code>vault-profile.md</code>，让后续工作流有稳定合约。",
+        flow4Title: "运行 specialist loops",
+        flow4Copy: "根据需要进入 ingest、maintenance、audit、working-profile、team-coordination 或 work-journal。",
+        flow5Title: "保持稳定",
+        flow5Copy: "持续做治理和导航检查，避免 vault 再次漂回混乱状态。",
+        rolesLabel: "固定模型",
+        rolesTitle: "5 种耐久页面角色",
+        rolesList: "<li><code>project</code>：导航、概览与边界</li><li><code>knowledge</code>：可复用的方法与概念</li><li><code>ops</code>：排障与操作流程</li><li><code>task</code>：任务分配与进行中工作</li><li><code>overview</code>：索引与治理面</li>",
+        journalLabel: "边界说明",
+        journalTitle: "Journal 不是第六种角色",
+        journalCopy: "Journal 内容可以更灵活，但真正耐久的知识应当被提升回固定 page-role model，而不是永远停留在日志里。",
+        ctaEyebrow: "从正确入口开始",
+        ctaTitle: "用 HTML 首页快速理解，用 GitHub 仓库拿到真正的工作包。",
+        ctaSub: "这个落地页负责让你快速看懂。真正权威的安装、路由、文档和发布物仍然在 GitHub 仓库里。",
+        ctaRepo: "打开 GitHub 仓库",
+        ctaStart: "前往 START-HERE",
+        nextLabel: "下一步入口",
+        nextTitle: "建议接着打开这些",
+        nextList: "<li><a href=\"https://github.com/zouxy111/wiki-knowledgebase-share-kit/blob/main/START-HERE.md\">START-HERE.md</a></li><li><a href=\"https://github.com/zouxy111/wiki-knowledgebase-share-kit/blob/main/GLOSSARY.md\">GLOSSARY.md</a></li><li><a href=\"https://github.com/zouxy111/wiki-knowledgebase-share-kit/blob/main/docs/example-prompts.md\">docs/example-prompts.md</a></li><li><a href=\"https://github.com/zouxy111/wiki-knowledgebase-share-kit/releases/latest\">最新版本</a></li><li><a href=\"https://github.com/zouxy111/wiki-knowledgebase-share-kit/issues\">Issues</a></li>",
+        footerCopy: "MIT 开源 · 开发者：邹星宇、杨琦",
+        footerRepo: "GitHub 仓库",
+        footerReleases: "版本发布",
+        footerIssues: "问题反馈"
+      }
+    };
+
+    const metaDescription = document.querySelector('meta[name="description"]');
+    const toggleButtons = Array.from(document.querySelectorAll('[data-lang-toggle]'));
+    const i18nTextNodes = document.querySelectorAll('[data-i18n]');
+    const i18nHtmlNodes = document.querySelectorAll('[data-i18n-html]');
+    const i18nAltNodes = document.querySelectorAll('[data-i18n-alt]');
+
+    function applyLanguage(lang) {
+      const locale = translations[lang] ? lang : 'en';
+      const dict = translations[locale];
+
+      document.documentElement.lang = locale === 'zh' ? 'zh-CN' : 'en';
+      document.title = dict.pageTitle;
+      metaDescription.setAttribute('content', dict.pageDescription);
+
+      i18nTextNodes.forEach((node) => {
+        const key = node.dataset.i18n;
+        if (dict[key]) node.textContent = dict[key];
+      });
+
+      i18nHtmlNodes.forEach((node) => {
+        const key = node.dataset.i18nHtml;
+        if (dict[key]) node.innerHTML = dict[key];
+      });
+
+      i18nAltNodes.forEach((node) => {
+        const key = node.dataset.i18nAlt;
+        if (dict[key]) node.setAttribute('alt', dict[key]);
+      });
+
+      toggleButtons.forEach((button) => {
+        button.classList.toggle('active', button.dataset.langToggle === locale);
+      });
+
+      localStorage.setItem('wiki-kit-lang', locale);
+    }
+
+    function initLanguage() {
+      const params = new URLSearchParams(window.location.search);
+      const queryLang = params.get('lang');
+      const saved = localStorage.getItem('wiki-kit-lang');
+      const browserIsZh = navigator.language && navigator.language.toLowerCase().startsWith('zh');
+      applyLanguage(queryLang || saved || (browserIsZh ? 'zh' : 'en'));
+    }
+
+    function initReveal() {
+      const items = document.querySelectorAll('.reveal');
+      if (!('IntersectionObserver' in window)) {
+        items.forEach((item) => item.classList.add('is-visible'));
+        return;
+      }
+
+      const observer = new IntersectionObserver((entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            entry.target.classList.add('is-visible');
+            observer.unobserve(entry.target);
+          }
+        });
+      }, { threshold: 0.16, rootMargin: '0px 0px -8% 0px' });
+
+      items.forEach((item) => {
+        const rect = item.getBoundingClientRect();
+        if (rect.top < window.innerHeight * 0.92) {
+          item.classList.add('is-instant', 'is-visible');
+          requestAnimationFrame(() => item.classList.remove('is-instant'));
+          return;
+        }
+        observer.observe(item);
+      });
+    }
+
+    toggleButtons.forEach((button) => {
+      button.addEventListener('click', () => applyLanguage(button.dataset.langToggle));
+    });
+
+    initLanguage();
+    if (document.readyState === 'loading') {
+      window.addEventListener('DOMContentLoaded', initReveal, { once: true });
+    } else {
+      initReveal();
+    }
+  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add a prominent HTML homepage entrypoint to `README.md` and `README.en.md`
- make the GitHub repository homepage link clearly to the existing GitHub Pages HTML landing page
- add a clickable preview image so the repository homepage visually surfaces the HTML interface

## Scope
- `README.md`
- `README.en.md`

## Validation
- HTML homepage CTA sanity checks passed locally
- relative link validation passed locally

## Note
This does not replace the GitHub repository homepage with raw HTML. Instead, it makes the HTML landing page immediately visible and accessible from the README surface.
