### PR TITLE
[codex] Add close-reading, incremental reruns, and candidate pages for ingest

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -155,6 +155,7 @@ Use `knowledge-base-ingest` to:
 - generate TOC, glossary candidates, and related-link suggestions
 - treat the first import as a **testable baseline** and improve it through iteration and regression checks
 - switch into **close-reading mode** for oversized sources so the AI can review batch packets with rolling context instead of attempting a shallow one-pass import
+- prefer changed-batches-only reruns after source edits, then generate candidate pages and a candidate link map for final landing
 
 Typical examples:
 - medical books, guidelines, papers

--- a/README.en.md
+++ b/README.en.md
@@ -156,6 +156,7 @@ Use `knowledge-base-ingest` to:
 - treat the first import as a **testable baseline** and improve it through iteration and regression checks
 - switch into **close-reading mode** for oversized sources so the AI can review batch packets with rolling context instead of attempting a shallow one-pass import
 - prefer changed-batches-only reruns after source edits, then generate candidate pages and a candidate link map for final landing
+- keep candidate pages closer to real vault pages by writing draft frontmatter and source metadata directly into them
 
 Typical examples:
 - medical books, guidelines, papers

--- a/README.en.md
+++ b/README.en.md
@@ -154,6 +154,7 @@ Use `knowledge-base-ingest` to:
 - split the source into overview / chapter / topic pages
 - generate TOC, glossary candidates, and related-link suggestions
 - treat the first import as a **testable baseline** and improve it through iteration and regression checks
+- switch into **close-reading mode** for oversized sources so the AI can review batch packets with rolling context instead of attempting a shallow one-pass import
 
 Typical examples:
 - medical books, guidelines, papers

--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@
 - 建立 toc、glossary candidates、related-link suggestions
 - 把第一版导入当成 **可测试基线**，通过迭代和回归继续优化结构
 - 遇到超大文本时切到 **close-reading mode**，按 batch 分块精读并维护 rolling state
+- source 后续变化时优先只重跑 changed batches，并生成 candidate pages / candidate link map
 
 适合：
 - 医学书籍 / 指南 / 文献整理

--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@
 - 把第一版导入当成 **可测试基线**，通过迭代和回归继续优化结构
 - 遇到超大文本时切到 **close-reading mode**，按 batch 分块精读并维护 rolling state
 - source 后续变化时优先只重跑 changed batches，并生成 candidate pages / candidate link map
+- candidate pages 会尽量带 draft frontmatter，让它们更接近可落库的 wiki 草稿页
 
 适合：
 - 医学书籍 / 指南 / 文献整理

--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@
 - 把长 source 拆成 overview / chapter / topic
 - 建立 toc、glossary candidates、related-link suggestions
 - 把第一版导入当成 **可测试基线**，通过迭代和回归继续优化结构
+- 遇到超大文本时切到 **close-reading mode**，按 batch 分块精读并维护 rolling state
 
 适合：
 - 医学书籍 / 指南 / 文献整理

--- a/START-HERE.md
+++ b/START-HERE.md
@@ -127,6 +127,8 @@ Use $knowledge-base-ingest to import this long Markdown source into my knowledge
 Read my vault profile first and treat the first import as a testable baseline rather than the final structure.
 ```
 
+如果是超大文本 / 整本书 / 需要分块精读，再明确要求它切到 `close-reading mode`，先生成 batch packets 和 rolling state，再逐轮汇总。
+
 ### 沉淀任务结果
 ```text
 Use $knowledge-base-maintenance to integrate this task result into my knowledge base.

--- a/START-HERE.md
+++ b/START-HERE.md
@@ -127,7 +127,7 @@ Use $knowledge-base-ingest to import this long Markdown source into my knowledge
 Read my vault profile first and treat the first import as a testable baseline rather than the final structure.
 ```
 
-如果是超大文本 / 整本书 / 需要分块精读，再明确要求它切到 `close-reading mode`，先生成 batch packets 和 rolling state，再逐轮汇总；如果后续 source 有修改，优先只重跑 changed batches。
+如果是超大文本 / 整本书 / 需要分块精读，再明确要求它切到 `close-reading mode`，先生成 batch packets 和 rolling state，再逐轮汇总；如果后续 source 有修改，优先只重跑 changed batches，并让 candidate pages 带上 draft frontmatter。
 
 ### 沉淀任务结果
 ```text

--- a/START-HERE.md
+++ b/START-HERE.md
@@ -127,7 +127,7 @@ Use $knowledge-base-ingest to import this long Markdown source into my knowledge
 Read my vault profile first and treat the first import as a testable baseline rather than the final structure.
 ```
 
-如果是超大文本 / 整本书 / 需要分块精读，再明确要求它切到 `close-reading mode`，先生成 batch packets 和 rolling state，再逐轮汇总。
+如果是超大文本 / 整本书 / 需要分块精读，再明确要求它切到 `close-reading mode`，先生成 batch packets 和 rolling state，再逐轮汇总；如果后续 source 有修改，优先只重跑 changed batches。
 
 ### 沉淀任务结果
 ```text

--- a/docs/example-prompts.md
+++ b/docs/example-prompts.md
@@ -45,6 +45,7 @@ Do not treat this as a one-pass import. Switch into close-reading mode:
 split the source into chunks, create batch packets, maintain a rolling reading state, extract one JSON note per batch, and only then synthesize chapter summaries, topic candidates, glossary seeds, and overview pages.
 Keep the run resumable so the next iteration can continue from completed batches instead of rereading the whole source.
 If the source changes later, rerun only the changed batches and generate candidate pages plus a candidate link map for final landing.
+Write draft frontmatter into candidate pages so they are closer to real vault pages instead of plain notes.
 ```
 
 ```text
@@ -54,6 +55,7 @@ If the source changes later, rerun only the changed batches and generate candida
 先拆 chunk，再生成 batch packets，维护 rolling reading state，每个 batch 输出一份 JSON 精读笔记，最后再汇总 chapter summaries、topic candidates、glossary seeds 和 overview 页。
 整个 run 必须支持断点续跑，下一轮不要从头重读整份材料。
 如果后续 source 有修改，也要尽量只重跑 changed batches，并输出 candidate pages 和 candidate link map，方便最后落页。
+candidate pages 还要带 draft frontmatter，这样它们更接近真正可落进 vault 的页面，而不是普通笔记草稿。
 ```
 
 ## 4. 我已经有 profile，想沉淀一轮任务结果

--- a/docs/example-prompts.md
+++ b/docs/example-prompts.md
@@ -36,6 +36,24 @@ Use a lightweight harness mindset: keep versioned structure outputs, compare spl
 Sync the stabilized structure back to the required entry pages.
 ```
 
+## 3B. 对超大文本启用分块精读
+
+```text
+Use $knowledge-base-ingest to import this oversized Markdown source into my knowledge base.
+Read my vault profile first.
+Do not treat this as a one-pass import. Switch into close-reading mode:
+split the source into chunks, create batch packets, maintain a rolling reading state, extract one JSON note per batch, and only then synthesize chapter summaries, topic candidates, glossary seeds, and overview pages.
+Keep the run resumable so the next iteration can continue from completed batches instead of rereading the whole source.
+```
+
+```text
+用 $knowledge-base-ingest 处理这份超大 Markdown 源材料并导入我的知识库。
+先读 vault profile。
+不要把这次当成一次性导入；请切到 close-reading mode：
+先拆 chunk，再生成 batch packets，维护 rolling reading state，每个 batch 输出一份 JSON 精读笔记，最后再汇总 chapter summaries、topic candidates、glossary seeds 和 overview 页。
+整个 run 必须支持断点续跑，下一轮不要从头重读整份材料。
+```
+
 ## 4. 我已经有 profile，想沉淀一轮任务结果
 
 ```text

--- a/docs/example-prompts.md
+++ b/docs/example-prompts.md
@@ -44,6 +44,7 @@ Read my vault profile first.
 Do not treat this as a one-pass import. Switch into close-reading mode:
 split the source into chunks, create batch packets, maintain a rolling reading state, extract one JSON note per batch, and only then synthesize chapter summaries, topic candidates, glossary seeds, and overview pages.
 Keep the run resumable so the next iteration can continue from completed batches instead of rereading the whole source.
+If the source changes later, rerun only the changed batches and generate candidate pages plus a candidate link map for final landing.
 ```
 
 ```text
@@ -52,6 +53,7 @@ Keep the run resumable so the next iteration can continue from completed batches
 不要把这次当成一次性导入；请切到 close-reading mode：
 先拆 chunk，再生成 batch packets，维护 rolling reading state，每个 batch 输出一份 JSON 精读笔记，最后再汇总 chapter summaries、topic candidates、glossary seeds 和 overview 页。
 整个 run 必须支持断点续跑，下一轮不要从头重读整份材料。
+如果后续 source 有修改，也要尽量只重跑 changed batches，并输出 candidate pages 和 candidate link map，方便最后落页。
 ```
 
 ## 4. 我已经有 profile，想沉淀一轮任务结果

--- a/docs/usage-sop.md
+++ b/docs/usage-sop.md
@@ -86,9 +86,11 @@
 1. 先用 `knowledge-base-ingest` 进入 close-reading mode
 2. 生成 chunk、batch packet 和 reading state
 3. 逐 batch 精读并写入 `batch-notes/*.json`
-4. 重跑 close-reading harness 刷新 rolling state
-5. 用 synthesis 汇总 chapter / topic / glossary 候选结果
-6. 最后再把稳定结构写回知识库
+4. source 变化后优先只重跑 changed batches
+5. 重跑 close-reading harness 刷新 rolling state
+6. 用 synthesis 汇总 chapter / topic / glossary 候选结果
+7. 生成 candidate pages 与 candidate link map
+8. 最后再把稳定结构写回知识库
 
 也就是：**先切块，再精读，再汇总，再落页**。
 
@@ -138,9 +140,11 @@
 2. 生成 `chunks/`、`batch-plan.json`、`reading-state.json`
 3. 逐 batch 精读 `batch-packets/*.md`
 4. 每轮把抽取结果写入 `batch-notes/<batch-id>.json`
-5. 重跑 harness，让后续 packet 读取最新 rolling state
-6. 运行 `scripts/synthesize_knowledge.py`
-7. 只把 overview / chapter / topic 的稳定候选结构写回知识库
+5. 只要 source 有局部变更，就优先只重跑 changed batches
+6. 重跑 harness，让后续 packet 读取最新 rolling state
+7. 运行 `scripts/synthesize_knowledge.py`
+8. 查看 candidate pages / candidate link map
+9. 只把 overview / chapter / topic 的稳定候选结构写回知识库
 
 ---
 

--- a/docs/usage-sop.md
+++ b/docs/usage-sop.md
@@ -23,6 +23,7 @@
 - 导入长 markdown 文档、书稿、教程或大章节
 - 先按章节/主题拆分，再建立 parent-child / prev-next / related links
 - 把第一次导入当成可测试基线，并通过对比、回归、重构继续优化结构
+- 对超大源材料切到 close-reading mode，按 batch 分块精读并保留 rolling state
 
 ### `knowledge-base-maintenance`
 用于：
@@ -81,6 +82,16 @@
 
 也就是：**先落基线，再迭代，再审**。
 
+### 场景 C2：超大文本 / 整本书 / 需要分块精读
+1. 先用 `knowledge-base-ingest` 进入 close-reading mode
+2. 生成 chunk、batch packet 和 reading state
+3. 逐 batch 精读并写入 `batch-notes/*.json`
+4. 重跑 close-reading harness 刷新 rolling state
+5. 用 synthesis 汇总 chapter / topic / glossary 候选结果
+6. 最后再把稳定结构写回知识库
+
+也就是：**先切块，再精读，再汇总，再落页**。
+
 ### 场景 D：任务完成后沉淀知识
 1. 先用 `knowledge-base-maintenance`
 2. 如果改动较大，再用 `knowledge-base-audit` 做复检
@@ -120,6 +131,16 @@
 6. 基于测试结果比较拆分方案、页面角色和维护成本
 7. 对入口页、来源链和关键导航做回归检查
 8. 汇报版本差异与最终稳定形态
+
+### 超大文本的 close-reading 回路
+
+1. 先运行 `scripts/close_read_markdown.py`
+2. 生成 `chunks/`、`batch-plan.json`、`reading-state.json`
+3. 逐 batch 精读 `batch-packets/*.md`
+4. 每轮把抽取结果写入 `batch-notes/<batch-id>.json`
+5. 重跑 harness，让后续 packet 读取最新 rolling state
+6. 运行 `scripts/synthesize_knowledge.py`
+7. 只把 overview / chapter / topic 的稳定候选结构写回知识库
 
 ---
 

--- a/docs/usage-sop.md
+++ b/docs/usage-sop.md
@@ -89,7 +89,7 @@
 4. source 变化后优先只重跑 changed batches
 5. 重跑 close-reading harness 刷新 rolling state
 6. 用 synthesis 汇总 chapter / topic / glossary 候选结果
-7. 生成 candidate pages 与 candidate link map
+7. 生成 candidate pages、candidate link map 和 draft frontmatter
 8. 最后再把稳定结构写回知识库
 
 也就是：**先切块，再精读，再汇总，再落页**。
@@ -143,7 +143,7 @@
 5. 只要 source 有局部变更，就优先只重跑 changed batches
 6. 重跑 harness，让后续 packet 读取最新 rolling state
 7. 运行 `scripts/synthesize_knowledge.py`
-8. 查看 candidate pages / candidate link map
+8. 查看 candidate pages / candidate link map / frontmatter 是否合理
 9. 只把 overview / chapter / topic 的稳定候选结构写回知识库
 
 ---

--- a/docs/usage-sop.md
+++ b/docs/usage-sop.md
@@ -139,7 +139,7 @@
 1. 先运行 `scripts/close_read_markdown.py`
 2. 生成 `chunks/`、`batch-plan.json`、`reading-state.json`
 3. 逐 batch 精读 `batch-packets/*.md`
-4. 每轮把抽取结果写入 `batch-notes/<batch-id>.json`
+4. 每轮把抽取结果写入 `batch-notes/<batch-key>.json`
 5. 只要 source 有局部变更，就优先只重跑 changed batches
 6. 重跑 harness，让后续 packet 读取最新 rolling state
 7. 运行 `scripts/synthesize_knowledge.py`

--- a/skills/knowledge-base-ingest/SKILL.md
+++ b/skills/knowledge-base-ingest/SKILL.md
@@ -163,6 +163,7 @@ close-reading mode 的目标是：
 如果在 close-reading mode：
 - 让 synthesis 产出 candidate pages
 - 让 candidate pages 自带 overview / prev-next / related topic links
+- 让 candidate pages 直接带 draft frontmatter / source metadata / candidate metadata
 - 额外产出 candidate link map，避免后续落页时重新猜链接
 
 如果某一页只是孤零零的摘录页，不应视为完成导入。
@@ -220,6 +221,7 @@ close-reading mode 的目标是：
 - close-reading run 是否有 batch plan / reading state / completed notes / synthesis 产物
 - rerun 时是否只重置了 changed batches，而不是整本书重读
 - synthesis 是否产出了 candidate pages 和 candidate link map
+- candidate pages 是否已经带 frontmatter，且 `area` / `owner` / `status` 是否明确
 - 是否做了 baseline vs candidate 的结构比较
 - 是否通过回归检查
 - 本轮最终决定是 promote / rework / drop
@@ -233,7 +235,7 @@ close-reading mode 的目标是：
 - `scripts/close_read_markdown.py`：为超大源材料生成 batch 级精读包、rolling state 和可续跑的 batch notes
 - `scripts/extract_terms.py`：提取 glossary candidates，输出 JSON 和 Markdown 列表
 - `scripts/suggest_related_links.py`：基于标题和关键词重合度生成 related links 建议
-- `scripts/synthesize_knowledge.py`：把 completed batch notes 汇总成 source overview / chapter summaries / topic candidates / candidate pages / candidate link map
+- `scripts/synthesize_knowledge.py`：把 completed batch notes 汇总成 source overview / chapter summaries / topic candidates / candidate pages / candidate link map，并给 candidate pages 写入 draft frontmatter
 
 ### references/
 - `references/vault-profile-contract.md`：导入前需要哪些 profile 信息

--- a/skills/knowledge-base-ingest/SKILL.md
+++ b/skills/knowledge-base-ingest/SKILL.md
@@ -120,7 +120,7 @@ close-reading mode 的目标是：
 执行时：
 - 先运行 `scripts/close_read_markdown.py`
 - 按 batch packet 逐轮精读
-- 每轮把抽取结果写入 `batch-notes/<batch-id>.json`
+- 每轮把抽取结果写入 `batch-notes/<batch-key>.json`
 - 反复重跑脚本以刷新 rolling state
 - 如果 source 改了，优先利用 chunk hash / batch hash 只重跑 changed batches
 - 需要汇总时运行：

--- a/skills/knowledge-base-ingest/SKILL.md
+++ b/skills/knowledge-base-ingest/SKILL.md
@@ -25,6 +25,9 @@ description: This skill should be used when the user asks to import a long markd
 - `references/ingest-iteration-loop.md`
 - `references/ingest-evaluation-rubric.md`
 - `references/chunking-strategy.md`
+- `references/close-reading-mode.md`
+- `references/rolling-state-contract.md`
+- `references/chunk-note-schema.md`
 - `references/glossary-strategy.md`
 - `references/linking-strategy.md`
 - `../../templates/vault-profile-template.md`
@@ -45,6 +48,7 @@ description: This skill should be used when the user asks to import a long markd
 - **先做 ingestion map，再动目标文件。** 先确定 part / chapter / section / topic 的落点。
 - **默认采用 overview / chapter / topic 三层结构。** 除非源材料本身有更适合的层级。
 - **先认定 stable baseline。** 如果不是第一次导入，本轮要明确“当前稳定版本”是什么。
+- **超大源材料要切到 close-reading mode。** 不要指望一次 prompt 读完整本书。
 - **优先知识库口径，而不是原文镜像口径。**
 - **保留 source lineage。** 每个导入页面都应能看出来自哪本书、哪一章、哪一节。
 - **链接优先级高于排版复刻。**
@@ -90,7 +94,36 @@ description: This skill should be used when the user asks to import a long markd
 - 过长章节再按更深一层标题拆分
 - 单页尽量保持在**一个可读、可维护的长度**，避免再次变成长页
 
-### 4. Classify by page role
+如果 source 已经大到不适合“一轮拆完立刻落页”，切到 close-reading mode：
+- `python3 scripts/close_read_markdown.py <source.md> --out <run-dir>`
+
+这个脚本会输出：
+- `chunks/`
+- `batch-plan.json`
+- `reading-state.json`
+- `batch-packets/`
+- `batch-notes/`
+
+close-reading mode 的目标是：
+- 让 AI 按 batch 分块精读
+- 让每一轮精读保留可恢复、可比较的中间状态
+- 让后续 synthesis 能跨 batch 累积理解，而不是每块重新开始
+
+### 4. Run close-reading mode for oversized sources
+当 source 满足任一条件时，优先进入 close-reading mode：
+- 超过 25,000 words
+- 或拆分后 chunk 数明显很多（例如 > 15）
+- 或用户明确要求“超大文本 / 分块精读 / 整本书精读”
+
+执行时：
+- 先运行 `scripts/close_read_markdown.py`
+- 按 batch packet 逐轮精读
+- 每轮把抽取结果写入 `batch-notes/<batch-id>.json`
+- 反复重跑脚本以刷新 rolling state
+- 需要汇总时运行：
+  - `python3 scripts/synthesize_knowledge.py <run-dir>`
+
+### 5. Classify by page role
 导入时仍遵循固定 page-role model：
 - `overview`：这本书 / 这份源材料的总览、目录、 ingestion rules
 - `knowledge`：概念、框架、模型、结论、定义、方法论
@@ -98,7 +131,7 @@ description: This skill should be used when the user asks to import a long markd
 - `project`：当 source 明显服务于某个长期专题主线时，作为稳定入口页
 - `task`：通常不作为书籍导入的主要落点，除非源文档本身就是协作任务结构
 
-### 5. Extract glossary and related-link suggestions
+### 6. Extract glossary and related-link suggestions
 需要辅助结构化时，可运行：
 - `python3 scripts/extract_terms.py <source-or-dir> --out <dir>`
 - `python3 scripts/suggest_related_links.py <dir> --top 3`
@@ -108,7 +141,7 @@ description: This skill should be used when the user asks to import a long markd
 - 为 chapter / topic 页面提供 related links 建议
 - 发现重复概念与潜在 hub 页面
 
-### 6. Rewrite into knowledge-base form
+### 7. Rewrite into knowledge-base form
 写入时：
 - 压缩重复叙述
 - 合并平行概念
@@ -116,7 +149,7 @@ description: This skill should be used when the user asks to import a long markd
 - 保留必要 source attribution（书名、章节、版本、作者）
 - 如需保留原文，只保留短引用和关键原句，避免大段照搬
 
-### 7. Create the link model
+### 8. Create the link model
 至少建立这些链接：
 - parent / child
 - prev / next
@@ -126,13 +159,13 @@ description: This skill should be used when the user asks to import a long markd
 
 如果某一页只是孤零零的摘录页，不应视为完成导入。
 
-### 8. Compare candidate structure to the stable baseline
+### 9. Compare candidate structure to the stable baseline
 如果当前不是第一次导入，而是在迭代已有结构：
 - 用 `references/ingest-evaluation-rubric.md` 的口径比较 baseline 和 candidate
 - 重点看拆分适配度、页面角色、导航覆盖、related links 是否真的更好
 - 只在 candidate 明显更利于检索、维护和回查时，才考虑晋升
 
-### 9. Run regression checks and record the round
+### 10. Run regression checks and record the round
 至少检查：
 - overview / root page / reader entrypoint 是否仍可达
 - source lineage 是否仍完整
@@ -143,7 +176,7 @@ description: This skill should be used when the user asks to import a long markd
 - 用 `../../templates/ingest-iteration-log-template.md` 记录 baseline / candidate / regression / decision
 - 决策为 promote / rework / drop 之一
 
-### 10. Sync navigation surfaces
+### 11. Sync navigation surfaces
 至少同步：
 - source overview page
 - 对应 root page
@@ -155,7 +188,7 @@ description: This skill should be used when the user asks to import a long markd
 - governance / maintainer overview
 - related topic hubs
 
-### 11. Validate before finishing
+### 12. Validate before finishing
 检查：
 - 有没有单页过长
 - 有没有只拆分但没建立链接
@@ -175,6 +208,8 @@ description: This skill should be used when the user asks to import a long markd
 - 建了哪些关键链接
 - 哪些原文被压缩 / 总结 / 改写
 - 是否抽取了 toc / glossary candidates / related links 建议
+- 是否启用了 close-reading mode
+- close-reading run 是否有 batch plan / reading state / completed notes / synthesis 产物
 - 是否做了 baseline vs candidate 的结构比较
 - 是否通过回归检查
 - 本轮最终决定是 promote / rework / drop
@@ -185,8 +220,10 @@ description: This skill should be used when the user asks to import a long markd
 
 ### scripts/
 - `scripts/split_markdown.py`：按标题层级做 deterministic split，输出 chunk 文件、manifest 和 toc
+- `scripts/close_read_markdown.py`：为超大源材料生成 batch 级精读包、rolling state 和可续跑的 batch notes
 - `scripts/extract_terms.py`：提取 glossary candidates，输出 JSON 和 Markdown 列表
 - `scripts/suggest_related_links.py`：基于标题和关键词重合度生成 related links 建议
+- `scripts/synthesize_knowledge.py`：把 completed batch notes 汇总成 source overview / chapter summaries / topic candidates
 
 ### references/
 - `references/vault-profile-contract.md`：导入前需要哪些 profile 信息
@@ -194,6 +231,9 @@ description: This skill should be used when the user asks to import a long markd
 - `references/ingest-iteration-loop.md`：如何把 ingest 当作稳定基线和候选结构的迭代回路
 - `references/ingest-evaluation-rubric.md`：如何判断候选结构是否值得晋升
 - `references/chunking-strategy.md`：如何决定 chapter / section / topic 的拆分粒度
+- `references/close-reading-mode.md`：什么时候切入超大文本的分块精读模式
+- `references/rolling-state-contract.md`：`reading-state.json` 和 `batch-notes/*.json` 应该如何保持稳定
+- `references/chunk-note-schema.md`：batch note 应提取哪些字段，如何避免变成流水账
 - `references/glossary-strategy.md`：术语页与 glossary candidates 的处理方式
 - `references/linking-strategy.md`：如何从 related links 建议落到真实 wiki 链接模型
 - `../../templates/ingest-iteration-log-template.md`：记录每轮 baseline / candidate / regression / decision

--- a/skills/knowledge-base-ingest/SKILL.md
+++ b/skills/knowledge-base-ingest/SKILL.md
@@ -49,6 +49,7 @@ description: This skill should be used when the user asks to import a long markd
 - **默认采用 overview / chapter / topic 三层结构。** 除非源材料本身有更适合的层级。
 - **先认定 stable baseline。** 如果不是第一次导入，本轮要明确“当前稳定版本”是什么。
 - **超大源材料要切到 close-reading mode。** 不要指望一次 prompt 读完整本书。
+- **超大源材料优先增量重跑。** 改动了哪个 chapter，就尽量只重跑受影响的 batches。
 - **优先知识库口径，而不是原文镜像口径。**
 - **保留 source lineage。** 每个导入页面都应能看出来自哪本书、哪一章、哪一节。
 - **链接优先级高于排版复刻。**
@@ -108,6 +109,7 @@ close-reading mode 的目标是：
 - 让 AI 按 batch 分块精读
 - 让每一轮精读保留可恢复、可比较的中间状态
 - 让后续 synthesis 能跨 batch 累积理解，而不是每块重新开始
+- 尽量保留 unchanged completed batches，只重置 changed batches
 
 ### 4. Run close-reading mode for oversized sources
 当 source 满足任一条件时，优先进入 close-reading mode：
@@ -120,6 +122,7 @@ close-reading mode 的目标是：
 - 按 batch packet 逐轮精读
 - 每轮把抽取结果写入 `batch-notes/<batch-id>.json`
 - 反复重跑脚本以刷新 rolling state
+- 如果 source 改了，优先利用 chunk hash / batch hash 只重跑 changed batches
 - 需要汇总时运行：
   - `python3 scripts/synthesize_knowledge.py <run-dir>`
 
@@ -156,6 +159,11 @@ close-reading mode 的目标是：
 - sibling / related
 - source overview backlink
 - root page / reader entrypoint entry
+
+如果在 close-reading mode：
+- 让 synthesis 产出 candidate pages
+- 让 candidate pages 自带 overview / prev-next / related topic links
+- 额外产出 candidate link map，避免后续落页时重新猜链接
 
 如果某一页只是孤零零的摘录页，不应视为完成导入。
 
@@ -210,6 +218,8 @@ close-reading mode 的目标是：
 - 是否抽取了 toc / glossary candidates / related links 建议
 - 是否启用了 close-reading mode
 - close-reading run 是否有 batch plan / reading state / completed notes / synthesis 产物
+- rerun 时是否只重置了 changed batches，而不是整本书重读
+- synthesis 是否产出了 candidate pages 和 candidate link map
 - 是否做了 baseline vs candidate 的结构比较
 - 是否通过回归检查
 - 本轮最终决定是 promote / rework / drop
@@ -223,7 +233,7 @@ close-reading mode 的目标是：
 - `scripts/close_read_markdown.py`：为超大源材料生成 batch 级精读包、rolling state 和可续跑的 batch notes
 - `scripts/extract_terms.py`：提取 glossary candidates，输出 JSON 和 Markdown 列表
 - `scripts/suggest_related_links.py`：基于标题和关键词重合度生成 related links 建议
-- `scripts/synthesize_knowledge.py`：把 completed batch notes 汇总成 source overview / chapter summaries / topic candidates
+- `scripts/synthesize_knowledge.py`：把 completed batch notes 汇总成 source overview / chapter summaries / topic candidates / candidate pages / candidate link map
 
 ### references/
 - `references/vault-profile-contract.md`：导入前需要哪些 profile 信息

--- a/skills/knowledge-base-ingest/agents/openai.yaml
+++ b/skills/knowledge-base-ingest/agents/openai.yaml
@@ -1,6 +1,6 @@
 interface:
   display_name: "Knowledge Base 导入"
   short_description: "拆分长文档并生成目录术语与关联链接后导入知识库"
-  default_prompt: "Use $knowledge-base-ingest to import this long markdown document or book into my knowledge base: split it into reusable pages, and if the source is oversized switch into close-reading mode with batch packets, rolling state, changed-batches-only reruns, candidate pages, a candidate link map, TOC, glossary candidates, related links, regression checks, and sync of the necessary entrypoints."
+  default_prompt: "Use $knowledge-base-ingest to import this long markdown document or book into my knowledge base: split it into reusable pages, and if the source is oversized switch into close-reading mode with batch packets, rolling state, changed-batches-only reruns, candidate pages with draft frontmatter, a candidate link map, TOC, glossary candidates, related links, regression checks, and sync of the necessary entrypoints."
 policy:
   allow_implicit_invocation: true

--- a/skills/knowledge-base-ingest/agents/openai.yaml
+++ b/skills/knowledge-base-ingest/agents/openai.yaml
@@ -1,6 +1,6 @@
 interface:
   display_name: "Knowledge Base 导入"
   short_description: "拆分长文档并生成目录术语与关联链接后导入知识库"
-  default_prompt: "Use $knowledge-base-ingest to import this long markdown document or book into my knowledge base: split it into reusable pages, compare the candidate structure against the current baseline, generate TOC and glossary candidates, suggest related links, run regression checks, and sync the necessary entrypoints."
+  default_prompt: "Use $knowledge-base-ingest to import this long markdown document or book into my knowledge base: split it into reusable pages, and if the source is oversized switch into close-reading mode with batch packets, rolling state, synthesis outputs, TOC, glossary candidates, related links, regression checks, and sync of the necessary entrypoints."
 policy:
   allow_implicit_invocation: true

--- a/skills/knowledge-base-ingest/agents/openai.yaml
+++ b/skills/knowledge-base-ingest/agents/openai.yaml
@@ -1,6 +1,6 @@
 interface:
   display_name: "Knowledge Base 导入"
   short_description: "拆分长文档并生成目录术语与关联链接后导入知识库"
-  default_prompt: "Use $knowledge-base-ingest to import this long markdown document or book into my knowledge base: split it into reusable pages, and if the source is oversized switch into close-reading mode with batch packets, rolling state, synthesis outputs, TOC, glossary candidates, related links, regression checks, and sync of the necessary entrypoints."
+  default_prompt: "Use $knowledge-base-ingest to import this long markdown document or book into my knowledge base: split it into reusable pages, and if the source is oversized switch into close-reading mode with batch packets, rolling state, changed-batches-only reruns, candidate pages, a candidate link map, TOC, glossary candidates, related links, regression checks, and sync of the necessary entrypoints."
 policy:
   allow_implicit_invocation: true

--- a/skills/knowledge-base-ingest/references/chunk-note-schema.md
+++ b/skills/knowledge-base-ingest/references/chunk-note-schema.md
@@ -1,0 +1,21 @@
+# Chunk / Batch Note Schema
+
+## Summary
+Use one JSON file per batch.
+The note should be short enough to compare across batches, but rich enough to synthesize later.
+
+## Field guidance
+- `summary`: short batch-level explanation of what this segment contributes
+- `key_claims`: reusable claims, not filler prose
+- `concepts`: terms, frameworks, or ideas that recur across the source
+- `procedures`: stepwise methods, runbooks, or repeatable moves
+- `entities`: named people, systems, organizations, datasets, tools
+- `open_questions`: conflicts, ambiguities, gaps, unclear scope
+- `cross_refs`: chunk files or batch ids that should be revisited together
+- `candidate_topics`: concepts likely worth promoting into standalone topic pages
+
+## Anti-patterns
+- copying long raw paragraphs from the source
+- writing full essays instead of extraction notes
+- mixing transient commentary with stable knowledge
+- leaving the batch note as an empty placeholder after reading

--- a/skills/knowledge-base-ingest/references/close-reading-mode.md
+++ b/skills/knowledge-base-ingest/references/close-reading-mode.md
@@ -21,8 +21,9 @@ Instead, create a stable reading harness that can:
 2. Review one batch packet at a time
 3. Save one JSON note per batch into `batch-notes/`
 4. Re-run the script to refresh rolling state and future packet context
-5. When enough batches are complete, run `scripts/synthesize_knowledge.py`
-6. Promote only the stable overview / chapter / topic outputs into the vault
+5. Prefer changed-batches-only continuation: keep unchanged completed notes, reset only batches whose chunk hash changed
+6. When enough batches are complete, run `scripts/synthesize_knowledge.py`
+7. Promote only the stable overview / chapter / topic outputs into the vault
 
 ## Important rule
 Close-reading mode is for **deep understanding of oversized sources**, not for dumping raw text into the knowledge base.

--- a/skills/knowledge-base-ingest/references/close-reading-mode.md
+++ b/skills/knowledge-base-ingest/references/close-reading-mode.md
@@ -1,0 +1,28 @@
+# Close-Reading Mode for Oversized Sources
+
+## When to switch into this mode
+Use close-reading mode when any of these is true:
+- the source is book-scale or handbook-scale
+- the source will split into many chunks and simple one-pass rewriting is too shallow
+- the user explicitly asks for chunked close reading / 分块精读 / 精读整本书
+- you need the AI to accumulate understanding across chapters instead of treating every chunk as isolated
+
+## Goal
+Do not only split the file.
+
+Instead, create a stable reading harness that can:
+- batch chunks into readable review packets
+- preserve rolling context from completed batches
+- collect reusable concepts, claims, procedures, and open questions
+- synthesize stable knowledge-base outputs after close reading
+
+## Recommended loop
+1. Run `scripts/close_read_markdown.py`
+2. Review one batch packet at a time
+3. Save one JSON note per batch into `batch-notes/`
+4. Re-run the script to refresh rolling state and future packet context
+5. When enough batches are complete, run `scripts/synthesize_knowledge.py`
+6. Promote only the stable overview / chapter / topic outputs into the vault
+
+## Important rule
+Close-reading mode is for **deep understanding of oversized sources**, not for dumping raw text into the knowledge base.

--- a/skills/knowledge-base-ingest/references/rolling-state-contract.md
+++ b/skills/knowledge-base-ingest/references/rolling-state-contract.md
@@ -36,12 +36,14 @@ It should only carry enough context to help the next batch stay coherent:
 - candidate topics worth promoting
 - unresolved questions worth watching
 
-## `batch-notes/<batch-id>.json`
+## `batch-notes/<batch-key>.json`
 Each completed batch note should use this shape:
 
 ```json
 {
   "batch_id": "batch-001",
+  "batch_key": "chapter-a-b01",
+  "batch_hash": "content-hash-for-this-batch",
   "status": "completed",
   "summary": "2-5 sentence batch summary",
   "key_claims": ["stable claim"],

--- a/skills/knowledge-base-ingest/references/rolling-state-contract.md
+++ b/skills/knowledge-base-ingest/references/rolling-state-contract.md
@@ -18,9 +18,11 @@ ingest-run/
 This file is the machine-readable snapshot of progress.
 It should at least track:
 - source path and source title
+- source hash
 - effective split level
 - total batch count
 - completed vs pending batches
+- changed / new / removed batches after a rerun
 - rolling snapshot of concepts / entities / candidate topics / open questions
 - per-batch status and packet/note paths
 
@@ -55,3 +57,11 @@ Each completed batch note should use this shape:
 ## Keep it stable
 Do not let batch notes drift into free-form diaries.
 They should stay compact, comparable, and suitable for later synthesis.
+
+## Incremental rerun rule
+If the chunk hash for a batch changes:
+- archive the old note for traceability
+- reset that batch to pending
+- keep other unchanged completed notes reusable
+
+Do not force the reader to re-read the whole source when only one chapter changed.

--- a/skills/knowledge-base-ingest/references/rolling-state-contract.md
+++ b/skills/knowledge-base-ingest/references/rolling-state-contract.md
@@ -1,0 +1,57 @@
+# Rolling State Contract
+
+## Run directory structure
+A close-reading run should produce a directory like this:
+
+```text
+ingest-run/
+  README.md
+  batch-plan.json
+  reading-state.json
+  chunks/
+  batch-packets/
+  batch-notes/
+  synthesis/
+```
+
+## `reading-state.json`
+This file is the machine-readable snapshot of progress.
+It should at least track:
+- source path and source title
+- effective split level
+- total batch count
+- completed vs pending batches
+- rolling snapshot of concepts / entities / candidate topics / open questions
+- per-batch status and packet/note paths
+
+## Rolling snapshot expectations
+The rolling snapshot should remain lightweight.
+It is not a full memory dump.
+It should only carry enough context to help the next batch stay coherent:
+- recent summaries
+- top repeated concepts
+- top entities
+- candidate topics worth promoting
+- unresolved questions worth watching
+
+## `batch-notes/<batch-id>.json`
+Each completed batch note should use this shape:
+
+```json
+{
+  "batch_id": "batch-001",
+  "status": "completed",
+  "summary": "2-5 sentence batch summary",
+  "key_claims": ["stable claim"],
+  "concepts": ["term or concept"],
+  "procedures": ["repeatable procedure"],
+  "entities": ["named entity"],
+  "open_questions": ["what remains unresolved"],
+  "cross_refs": ["related chunk or batch id"],
+  "candidate_topics": ["topic page candidate"]
+}
+```
+
+## Keep it stable
+Do not let batch notes drift into free-form diaries.
+They should stay compact, comparable, and suitable for later synthesis.

--- a/skills/knowledge-base-ingest/scripts/close_read_markdown.py
+++ b/skills/knowledge-base-ingest/scripts/close_read_markdown.py
@@ -2,7 +2,9 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
+import shutil
 from collections import Counter
 from dataclasses import dataclass
 from datetime import datetime
@@ -12,6 +14,7 @@ from typing import Iterable
 from split_markdown import (
     choose_level,
     find_headings,
+    slugify,
     split_range,
     write_chunks,
     write_toc,
@@ -31,6 +34,8 @@ NOTE_LIST_FIELDS = [
 @dataclass
 class Batch:
     batch_id: str
+    batch_key: str
+    batch_hash: str
     chapter_key: str
     chunk_files: list[str]
     chunk_titles: list[str]
@@ -40,6 +45,8 @@ class Batch:
 @dataclass
 class CompletedNote:
     batch_id: str
+    batch_key: str
+    batch_hash: str
     summary: str
     key_claims: list[str]
     concepts: list[str]
@@ -67,6 +74,14 @@ def write_json(path: Path, payload) -> None:
     )
 
 
+def sha1_text(text: str) -> str:
+    return hashlib.sha1(text.encode("utf-8")).hexdigest()
+
+
+def file_sha1(path: Path) -> str:
+    return sha1_text(path.read_text(encoding="utf-8"))
+
+
 def normalize_list(value) -> list[str]:
     if value is None:
         return []
@@ -91,6 +106,27 @@ def make_source_title(lines: list[str], source: Path) -> str:
     return source.stem
 
 
+def enrich_manifest_hashes(manifest: list[dict], chunks_dir: Path) -> list[dict]:
+    enriched = []
+    for item in manifest:
+        new_item = dict(item)
+        chunk_path = chunks_dir / new_item["file"]
+        if chunk_path.exists():
+            new_item["content_hash"] = file_sha1(chunk_path)
+        enriched.append(new_item)
+    return enriched
+
+
+def reset_generated_chunk_artifacts(chunks_dir: Path) -> None:
+    if not chunks_dir.exists():
+        return
+    for path in chunks_dir.iterdir():
+        if path.is_file():
+            path.unlink()
+        elif path.is_dir():
+            shutil.rmtree(path)
+
+
 def prepare_chunks(
     source: Path,
     chunks_dir: Path,
@@ -98,16 +134,27 @@ def prepare_chunks(
     max_chunk_words: int,
     prefix: str,
     force_resplit: bool,
-) -> tuple[list[dict], int, str]:
+) -> tuple[list[dict], int, str, str]:
     manifest_path = chunks_dir / "manifest.json"
     meta_path = chunks_dir / "source-metadata.json"
+    source_text = source.read_text(encoding="utf-8")
+    source_hash = sha1_text(source_text)
+
     if manifest_path.exists() and meta_path.exists() and not force_resplit:
-        manifest = read_json(manifest_path)
         meta = read_json(meta_path)
-        return manifest, int(meta["effective_level"]), str(meta["source_title"])
+        if meta.get("source_hash") == source_hash:
+            manifest = enrich_manifest_hashes(read_json(manifest_path), chunks_dir)
+            write_json(manifest_path, manifest)
+            return (
+                manifest,
+                int(meta["effective_level"]),
+                str(meta["source_title"]),
+                source_hash,
+            )
 
     chunks_dir.mkdir(parents=True, exist_ok=True)
-    lines = source.read_text(encoding="utf-8").splitlines(keepends=True)
+    reset_generated_chunk_artifacts(chunks_dir)
+    lines = source_text.splitlines(keepends=True)
     headings = find_headings(lines)
     if not headings:
         raise SystemExit("No markdown headings found; add headings or split manually.")
@@ -123,10 +170,9 @@ def prepare_chunks(
         preamble = lines[:preamble_start]
         if "".join(preamble).strip():
             preamble_path.write_text("".join(preamble), encoding="utf-8")
-    elif preamble_path.exists():
-        preamble_path.unlink()
 
     manifest = write_chunks(chunks, chunks_dir, prefix)
+    manifest = enrich_manifest_hashes(manifest, chunks_dir)
     write_json(manifest_path, manifest)
     write_toc(manifest, chunks_dir)
     source_title = make_source_title(lines, source)
@@ -135,12 +181,13 @@ def prepare_chunks(
         {
             "source": str(source),
             "source_title": source_title,
+            "source_hash": source_hash,
             "effective_level": effective_level,
             "generated_at": now_iso(),
             "chunk_count": len(manifest),
         },
     )
-    return manifest, effective_level, source_title
+    return manifest, effective_level, source_title, source_hash
 
 
 def chapter_key(item: dict) -> str:
@@ -148,6 +195,19 @@ def chapter_key(item: dict) -> str:
     if len(breadcrumb) >= 2:
         return " / ".join(breadcrumb[:2])
     return breadcrumb[0]
+
+
+def make_batch_hash(items: list[dict]) -> str:
+    payload = [
+        {
+            "file": item["file"],
+            "title": item.get("title"),
+            "hash": item.get("content_hash", ""),
+            "words": int(item.get("word_count", 0)),
+        }
+        for item in items
+    ]
+    return sha1_text(json.dumps(payload, ensure_ascii=False, sort_keys=True))
 
 
 def plan_batches(
@@ -159,15 +219,22 @@ def plan_batches(
     current_items: list[dict] = []
     current_words = 0
     current_chapter: str | None = None
+    chapter_counts: Counter[str] = Counter()
 
     def flush() -> None:
         nonlocal current_items, current_words, current_chapter
         if not current_items:
             return
-        batch_id = f"batch-{len(batches) + 1:03d}"
+        chapter_slug = slugify(current_chapter or "ungrouped")
+        chapter_counts[chapter_slug] += 1
+        batch_index = chapter_counts[chapter_slug]
+        batch_key = f"{chapter_slug}-b{batch_index:02d}"
+        batch_hash = make_batch_hash(current_items)
         batches.append(
             Batch(
-                batch_id=batch_id,
+                batch_id=f"batch-{len(batches) + 1:03d}",
+                batch_key=batch_key,
+                batch_hash=batch_hash,
                 chapter_key=current_chapter or "Ungrouped",
                 chunk_files=[item["file"] for item in current_items],
                 chunk_titles=[item["title"] for item in current_items],
@@ -202,6 +269,8 @@ def plan_batches(
 def note_template(batch: Batch) -> dict:
     return {
         "batch_id": batch.batch_id,
+        "batch_key": batch.batch_key,
+        "batch_hash": batch.batch_hash,
         "status": "pending",
         "summary": "",
         "key_claims": [],
@@ -214,20 +283,30 @@ def note_template(batch: Batch) -> dict:
     }
 
 
-def load_completed_note(path: Path) -> CompletedNote | None:
-    if not path.exists():
-        return None
-    payload = read_json(path)
+def has_meaningful_note(payload: dict) -> bool:
     summary = " ".join(str(payload.get("summary", "")).split()).strip()
+    if summary:
+        return True
+    for field in NOTE_LIST_FIELDS:
+        if normalize_list(payload.get(field, [])):
+            return True
+    return False
+
+
+def parse_completed_note(path: Path, payload: dict) -> CompletedNote | None:
     status = str(payload.get("status", "pending")).strip().lower() or "pending"
+    if status != "completed" and not has_meaningful_note(payload):
+        return None
+    summary = " ".join(str(payload.get("summary", "")).split()).strip()
     lists = {
         field: normalize_list(payload.get(field, [])) for field in NOTE_LIST_FIELDS
     }
-    meaningful = summary or any(lists[field] for field in NOTE_LIST_FIELDS)
-    if not meaningful and status != "completed":
+    if not summary and not any(lists[field] for field in NOTE_LIST_FIELDS):
         return None
     return CompletedNote(
         batch_id=str(payload.get("batch_id", path.stem)),
+        batch_key=str(payload.get("batch_key", path.stem)),
+        batch_hash=str(payload.get("batch_hash", "")),
         summary=summary,
         key_claims=lists["key_claims"],
         concepts=lists["concepts"],
@@ -239,6 +318,17 @@ def load_completed_note(path: Path) -> CompletedNote | None:
         status=status,
         note_path=str(path),
     )
+
+
+def archive_note(path: Path, stale_dir: Path, suffix: str) -> Path:
+    stale_dir.mkdir(parents=True, exist_ok=True)
+    archived = stale_dir / f"{path.stem}--{suffix}{path.suffix}"
+    counter = 2
+    while archived.exists():
+        archived = stale_dir / f"{path.stem}--{suffix}-{counter}{path.suffix}"
+        counter += 1
+    shutil.move(str(path), str(archived))
+    return archived
 
 
 def build_rolling_snapshot(completed_notes: Iterable[CompletedNote]) -> dict:
@@ -324,6 +414,11 @@ def render_packet(
     note_path: Path,
     snapshot: dict,
 ) -> str:
+    note_link = f"../{note_path.parent.name}/{note_path.name}"
+    chunk_links = [
+        f"[{chunk_file}](../{chunk_dir.name}/{chunk_file})"
+        for chunk_file in batch.chunk_files
+    ]
     lines = [
         f"# Close Reading Packet — {batch.batch_id}",
         "",
@@ -331,8 +426,10 @@ def render_packet(
         "",
         f"- Source: {source_title}",
         f"- Batch: {batch_index}/{total_batches}",
+        f"- Batch key: `{batch.batch_key}`",
+        f"- Batch hash: `{batch.batch_hash}`",
         f"- Chapter key: {batch.chapter_key}",
-        f"- Chunk files: {', '.join(batch.chunk_files)}",
+        f"- Chunk files: {', '.join(chunk_links)}",
         f"- Total words in this batch: {batch.total_words}",
         "",
         render_snapshot_section(snapshot),
@@ -341,7 +438,7 @@ def render_packet(
         "",
         "Write one JSON note for this batch. Keep the output faithful to the source and optimized for later synthesis.",
         "",
-        f"- Save JSON to: `{note_path}`",
+        f"- Save JSON to: [{note_path.name}]({note_link})",
         "- Keep `summary` to 2-5 sentences.",
         "- Use short bullet-like strings for arrays.",
         "- Add only stable, reusable claims and concepts; skip filler prose.",
@@ -361,7 +458,7 @@ def render_packet(
         chunk_text = (chunk_dir / chunk_file).read_text(encoding="utf-8")
         lines.extend(
             [
-                f"### {chunk_title} ({chunk_file})",
+                f"### {chunk_title} ([{chunk_file}](../{chunk_dir.name}/{chunk_file}))",
                 "",
                 "```markdown",
                 chunk_text.rstrip(),
@@ -386,58 +483,57 @@ def prepare_run(
     chunks_dir = out_dir / "chunks"
     batch_packets_dir = out_dir / "batch-packets"
     batch_notes_dir = out_dir / "batch-notes"
+    stale_notes_dir = out_dir / "stale-notes"
     batch_packets_dir.mkdir(exist_ok=True)
     batch_notes_dir.mkdir(exist_ok=True)
+    stale_notes_dir.mkdir(exist_ok=True)
 
-    manifest, effective_level, source_title = prepare_chunks(
+    manifest, effective_level, source_title, source_hash = prepare_chunks(
         source, chunks_dir, level, max_chunk_words, prefix, force_resplit
     )
     batches = plan_batches(manifest, max_batch_words, max_chunks_per_batch)
-    write_json(
-        out_dir / "batch-plan.json",
-        {
-            "source": str(source),
-            "source_title": source_title,
-            "generated_at": now_iso(),
-            "effective_split_level": effective_level,
-            "max_chunk_words": max_chunk_words,
-            "max_batch_words": max_batch_words,
-            "max_chunks_per_batch": max_chunks_per_batch,
-            "batches": [batch.__dict__ for batch in batches],
-        },
-    )
+
+    active_batch_keys = {batch.batch_key for batch in batches}
+    removed_batches = []
+    for existing_note in sorted(batch_notes_dir.glob("*.json")):
+        if existing_note.stem not in active_batch_keys:
+            archive_note(
+                existing_note, stale_notes_dir, f"removed-{now_iso().replace(':', '-')}"
+            )
+            removed_batches.append(existing_note.stem)
 
     notes_by_batch: dict[str, CompletedNote] = {}
-    for batch in batches:
-        note_path = batch_notes_dir / f"{batch.batch_id}.json"
-        if not note_path.exists():
-            write_json(note_path, note_template(batch))
-        note = load_completed_note(note_path)
-        if note is not None:
-            notes_by_batch[batch.batch_id] = note
-
-    completed_before_current: list[CompletedNote] = []
+    changed_batches = 0
+    new_batches = 0
     batch_rows = []
-    for idx, batch in enumerate(batches, start=1):
-        note_path = batch_notes_dir / f"{batch.batch_id}.json"
-        snapshot = build_rolling_snapshot(completed_before_current)
-        packet_text = render_packet(
-            batch,
-            source_title,
-            idx,
-            len(batches),
-            chunks_dir,
-            note_path,
-            snapshot,
-        )
-        packet_path = batch_packets_dir / f"{batch.batch_id}.md"
-        packet_path.write_text(packet_text, encoding="utf-8")
 
-        status = "completed" if batch.batch_id in notes_by_batch else "pending"
+    for batch in batches:
+        note_path = batch_notes_dir / f"{batch.batch_key}.json"
+        change_status = "unchanged"
+        if note_path.exists():
+            payload = read_json(note_path)
+            if str(payload.get("batch_hash", "")) != batch.batch_hash:
+                if has_meaningful_note(payload):
+                    archive_note(note_path, stale_notes_dir, batch.batch_hash[:10])
+                write_json(note_path, note_template(batch))
+                change_status = "changed"
+                changed_batches += 1
+            else:
+                note = parse_completed_note(note_path, payload)
+                if note is not None and note.status == "completed":
+                    notes_by_batch[batch.batch_key] = note
+        else:
+            write_json(note_path, note_template(batch))
+            change_status = "new"
+            new_batches += 1
+
+        packet_path = batch_packets_dir / f"{batch.batch_key}.md"
         batch_rows.append(
             {
                 "batch_id": batch.batch_id,
-                "status": status,
+                "batch_key": batch.batch_key,
+                "batch_hash": batch.batch_hash,
+                "change_status": change_status,
                 "chapter_key": batch.chapter_key,
                 "chunk_files": batch.chunk_files,
                 "chunk_titles": batch.chunk_titles,
@@ -446,27 +542,58 @@ def prepare_run(
                 "packet_file": str(packet_path.relative_to(out_dir)),
             }
         )
-        if batch.batch_id in notes_by_batch:
-            completed_before_current.append(notes_by_batch[batch.batch_id])
+
+    completed_before_current: list[CompletedNote] = []
+    for idx, row in enumerate(batch_rows, start=1):
+        batch = next(item for item in batches if item.batch_key == row["batch_key"])
+        note_path = out_dir / row["note_file"]
+        snapshot = build_rolling_snapshot(completed_before_current)
+        packet_text = render_packet(
+            batch, source_title, idx, len(batch_rows), chunks_dir, note_path, snapshot
+        )
+        (out_dir / row["packet_file"]).write_text(packet_text, encoding="utf-8")
+        if row["batch_key"] in notes_by_batch:
+            row["status"] = "completed"
+            completed_before_current.append(notes_by_batch[row["batch_key"]])
+        else:
+            row["status"] = "pending"
 
     completed_notes = [
-        notes_by_batch[row["batch_id"]]
+        notes_by_batch[row["batch_key"]]
         for row in batch_rows
-        if row["batch_id"] in notes_by_batch
+        if row["batch_key"] in notes_by_batch
     ]
     snapshot = build_rolling_snapshot(completed_notes)
     completed_chunks = sum(
         len(row["chunk_files"]) for row in batch_rows if row["status"] == "completed"
     )
+
+    batch_plan = {
+        "source": str(source),
+        "source_title": source_title,
+        "source_hash": source_hash,
+        "generated_at": now_iso(),
+        "effective_split_level": effective_level,
+        "max_chunk_words": max_chunk_words,
+        "max_batch_words": max_batch_words,
+        "max_chunks_per_batch": max_chunks_per_batch,
+        "batches": batch_rows,
+    }
+    write_json(out_dir / "batch-plan.json", batch_plan)
+
     reading_state = {
         "source": str(source),
         "source_title": source_title,
+        "source_hash": source_hash,
         "generated_at": now_iso(),
         "effective_split_level": effective_level,
         "batch_count": len(batch_rows),
         "completed_batches": len(completed_notes),
         "pending_batches": len(batch_rows) - len(completed_notes),
         "completed_chunks": completed_chunks,
+        "changed_batches": changed_batches,
+        "new_batches": new_batches,
+        "removed_batches": removed_batches,
         "snapshot": snapshot,
         "batches": batch_rows,
     }
@@ -477,17 +604,24 @@ def prepare_run(
         "",
         f"- Source: `{source}`",
         f"- Source title: {source_title}",
+        f"- Source hash: `{source_hash}`",
         f"- Effective split level: H{effective_level}",
         f"- Batches: {len(batch_rows)}",
         f"- Completed batches: {len(completed_notes)}",
+        f"- Changed batches: {changed_batches}",
+        f"- New batches: {new_batches}",
+        f"- Removed batches archived: {len(removed_batches)}",
         "",
         "## Batch queue",
         "",
+        "| Batch | Status | Change | Packet | Note |",
+        "|---|---|---|---|---|",
     ]
     for row in batch_rows:
+        packet_link = f"[{Path(row['packet_file']).name}]({row['packet_file']})"
+        note_link = f"[{Path(row['note_file']).name}]({row['note_file']})"
         index_lines.append(
-            f"- **{row['batch_id']}** [{row['status']}] — {row['chapter_key']} "
-            f"({len(row['chunk_files'])} chunks, {row['total_words']} words)"
+            f"| `{row['batch_key']}` | {row['status']} | {row['change_status']} | {packet_link} | {note_link} |"
         )
     (out_dir / "README.md").write_text("\n".join(index_lines) + "\n", encoding="utf-8")
     return reading_state

--- a/skills/knowledge-base-ingest/scripts/close_read_markdown.py
+++ b/skills/knowledge-base-ingest/scripts/close_read_markdown.py
@@ -501,6 +501,9 @@ def prepare_run(
                 existing_note, stale_notes_dir, f"removed-{now_iso().replace(':', '-')}"
             )
             removed_batches.append(existing_note.stem)
+    for existing_packet in sorted(batch_packets_dir.glob("*.md")):
+        if existing_packet.stem not in active_batch_keys:
+            existing_packet.unlink()
 
     notes_by_batch: dict[str, CompletedNote] = {}
     changed_batches = 0

--- a/skills/knowledge-base-ingest/scripts/close_read_markdown.py
+++ b/skills/knowledge-base-ingest/scripts/close_read_markdown.py
@@ -1,0 +1,553 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from collections import Counter
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Iterable
+
+from split_markdown import (
+    choose_level,
+    find_headings,
+    split_range,
+    write_chunks,
+    write_toc,
+)
+
+NOTE_LIST_FIELDS = [
+    "key_claims",
+    "concepts",
+    "procedures",
+    "entities",
+    "open_questions",
+    "cross_refs",
+    "candidate_topics",
+]
+
+
+@dataclass
+class Batch:
+    batch_id: str
+    chapter_key: str
+    chunk_files: list[str]
+    chunk_titles: list[str]
+    total_words: int
+
+
+@dataclass
+class CompletedNote:
+    batch_id: str
+    summary: str
+    key_claims: list[str]
+    concepts: list[str]
+    procedures: list[str]
+    entities: list[str]
+    open_questions: list[str]
+    cross_refs: list[str]
+    candidate_topics: list[str]
+    status: str
+    note_path: str
+
+
+def now_iso() -> str:
+    return datetime.now().replace(microsecond=0).isoformat()
+
+
+def read_json(path: Path):
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def write_json(path: Path, payload) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8"
+    )
+
+
+def normalize_list(value) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        value = [value]
+    if not isinstance(value, list):
+        return []
+    normalized = []
+    for item in value:
+        if not isinstance(item, str):
+            continue
+        text = " ".join(item.split()).strip()
+        if text:
+            normalized.append(text)
+    return normalized
+
+
+def make_source_title(lines: list[str], source: Path) -> str:
+    headings = find_headings(lines)
+    if headings:
+        return headings[0].title
+    return source.stem
+
+
+def prepare_chunks(
+    source: Path,
+    chunks_dir: Path,
+    level: int,
+    max_chunk_words: int,
+    prefix: str,
+    force_resplit: bool,
+) -> tuple[list[dict], int, str]:
+    manifest_path = chunks_dir / "manifest.json"
+    meta_path = chunks_dir / "source-metadata.json"
+    if manifest_path.exists() and meta_path.exists() and not force_resplit:
+        manifest = read_json(manifest_path)
+        meta = read_json(meta_path)
+        return manifest, int(meta["effective_level"]), str(meta["source_title"])
+
+    chunks_dir.mkdir(parents=True, exist_ok=True)
+    lines = source.read_text(encoding="utf-8").splitlines(keepends=True)
+    headings = find_headings(lines)
+    if not headings:
+        raise SystemExit("No markdown headings found; add headings or split manually.")
+
+    effective_level = choose_level(headings, level)
+    chunks = split_range(
+        lines, headings, effective_level, 0, len(lines), max_chunk_words
+    )
+
+    preamble_start = headings[0].line_index
+    preamble_path = chunks_dir / "000-preamble.md"
+    if preamble_start > 0:
+        preamble = lines[:preamble_start]
+        if "".join(preamble).strip():
+            preamble_path.write_text("".join(preamble), encoding="utf-8")
+    elif preamble_path.exists():
+        preamble_path.unlink()
+
+    manifest = write_chunks(chunks, chunks_dir, prefix)
+    write_json(manifest_path, manifest)
+    write_toc(manifest, chunks_dir)
+    source_title = make_source_title(lines, source)
+    write_json(
+        meta_path,
+        {
+            "source": str(source),
+            "source_title": source_title,
+            "effective_level": effective_level,
+            "generated_at": now_iso(),
+            "chunk_count": len(manifest),
+        },
+    )
+    return manifest, effective_level, source_title
+
+
+def chapter_key(item: dict) -> str:
+    breadcrumb = item.get("breadcrumb") or [item.get("title", "Untitled")]
+    if len(breadcrumb) >= 2:
+        return " / ".join(breadcrumb[:2])
+    return breadcrumb[0]
+
+
+def plan_batches(
+    manifest: list[dict],
+    max_batch_words: int,
+    max_chunks_per_batch: int,
+) -> list[Batch]:
+    batches: list[Batch] = []
+    current_items: list[dict] = []
+    current_words = 0
+    current_chapter: str | None = None
+
+    def flush() -> None:
+        nonlocal current_items, current_words, current_chapter
+        if not current_items:
+            return
+        batch_id = f"batch-{len(batches) + 1:03d}"
+        batches.append(
+            Batch(
+                batch_id=batch_id,
+                chapter_key=current_chapter or "Ungrouped",
+                chunk_files=[item["file"] for item in current_items],
+                chunk_titles=[item["title"] for item in current_items],
+                total_words=sum(
+                    int(item.get("word_count", 0)) for item in current_items
+                ),
+            )
+        )
+        current_items = []
+        current_words = 0
+        current_chapter = None
+
+    for item in manifest:
+        item_words = int(item.get("word_count", 0))
+        item_chapter = chapter_key(item)
+        exceeds_word_budget = (
+            current_items and current_words + item_words > max_batch_words
+        )
+        exceeds_chunk_budget = (
+            current_items and len(current_items) >= max_chunks_per_batch
+        )
+        chapter_switched = current_items and item_chapter != current_chapter
+        if exceeds_word_budget or exceeds_chunk_budget or chapter_switched:
+            flush()
+        current_items.append(item)
+        current_words += item_words
+        current_chapter = item_chapter
+    flush()
+    return batches
+
+
+def note_template(batch: Batch) -> dict:
+    return {
+        "batch_id": batch.batch_id,
+        "status": "pending",
+        "summary": "",
+        "key_claims": [],
+        "concepts": [],
+        "procedures": [],
+        "entities": [],
+        "open_questions": [],
+        "cross_refs": [],
+        "candidate_topics": [],
+    }
+
+
+def load_completed_note(path: Path) -> CompletedNote | None:
+    if not path.exists():
+        return None
+    payload = read_json(path)
+    summary = " ".join(str(payload.get("summary", "")).split()).strip()
+    status = str(payload.get("status", "pending")).strip().lower() or "pending"
+    lists = {
+        field: normalize_list(payload.get(field, [])) for field in NOTE_LIST_FIELDS
+    }
+    meaningful = summary or any(lists[field] for field in NOTE_LIST_FIELDS)
+    if not meaningful and status != "completed":
+        return None
+    return CompletedNote(
+        batch_id=str(payload.get("batch_id", path.stem)),
+        summary=summary,
+        key_claims=lists["key_claims"],
+        concepts=lists["concepts"],
+        procedures=lists["procedures"],
+        entities=lists["entities"],
+        open_questions=lists["open_questions"],
+        cross_refs=lists["cross_refs"],
+        candidate_topics=lists["candidate_topics"],
+        status=status,
+        note_path=str(path),
+    )
+
+
+def build_rolling_snapshot(completed_notes: Iterable[CompletedNote]) -> dict:
+    if not isinstance(completed_notes, list):
+        completed_notes = list(completed_notes)
+    summaries: list[str] = []
+    concept_counter: Counter[str] = Counter()
+    entity_counter: Counter[str] = Counter()
+    topic_counter: Counter[str] = Counter()
+    open_questions: list[str] = []
+    claim_counter: Counter[str] = Counter()
+
+    for note in completed_notes:
+        if note.summary:
+            summaries.append(note.summary)
+        concept_counter.update(note.concepts)
+        entity_counter.update(note.entities)
+        topic_counter.update(note.candidate_topics)
+        claim_counter.update(note.key_claims)
+        for question in note.open_questions:
+            if question not in open_questions:
+                open_questions.append(question)
+
+    return {
+        "completed_batches": len(completed_notes),
+        "recent_summaries": summaries[-3:],
+        "top_concepts": [
+            {"term": term, "count": count}
+            for term, count in concept_counter.most_common(12)
+        ],
+        "top_entities": [
+            {"term": term, "count": count}
+            for term, count in entity_counter.most_common(12)
+        ],
+        "candidate_topics": [
+            {"term": term, "count": count}
+            for term, count in topic_counter.most_common(12)
+        ],
+        "repeated_claims": [
+            {"claim": claim, "count": count}
+            for claim, count in claim_counter.most_common(8)
+        ],
+        "open_questions": open_questions[:12],
+        "latest_summary": summaries[-1] if summaries else "",
+    }
+
+
+def render_snapshot_section(snapshot: dict) -> str:
+    def render_counter(title: str, items: list[dict], key: str = "term") -> list[str]:
+        if not items:
+            return [f"- {title}: none yet"]
+        lines = [f"- {title}:"]
+        for item in items[:6]:
+            lines.append(f"  - {item[key]} (x{item['count']})")
+        return lines
+
+    lines = ["## Rolling context from completed batches", ""]
+    lines.append(f"- Completed batches so far: {snapshot['completed_batches']}")
+    if snapshot["recent_summaries"]:
+        lines.append("- Recent summaries:")
+        for summary in snapshot["recent_summaries"]:
+            lines.append(f"  - {summary}")
+    else:
+        lines.append("- Recent summaries: none yet")
+    lines.extend(render_counter("Top concepts", snapshot["top_concepts"]))
+    lines.extend(render_counter("Top entities", snapshot["top_entities"]))
+    lines.extend(render_counter("Candidate topics", snapshot["candidate_topics"]))
+    if snapshot["open_questions"]:
+        lines.append("- Open questions:")
+        for question in snapshot["open_questions"][:6]:
+            lines.append(f"  - {question}")
+    else:
+        lines.append("- Open questions: none yet")
+    return "\n".join(lines)
+
+
+def render_packet(
+    batch: Batch,
+    source_title: str,
+    batch_index: int,
+    total_batches: int,
+    chunk_dir: Path,
+    note_path: Path,
+    snapshot: dict,
+) -> str:
+    lines = [
+        f"# Close Reading Packet — {batch.batch_id}",
+        "",
+        "## Batch identity",
+        "",
+        f"- Source: {source_title}",
+        f"- Batch: {batch_index}/{total_batches}",
+        f"- Chapter key: {batch.chapter_key}",
+        f"- Chunk files: {', '.join(batch.chunk_files)}",
+        f"- Total words in this batch: {batch.total_words}",
+        "",
+        render_snapshot_section(snapshot),
+        "",
+        "## What to extract",
+        "",
+        "Write one JSON note for this batch. Keep the output faithful to the source and optimized for later synthesis.",
+        "",
+        f"- Save JSON to: `{note_path}`",
+        "- Keep `summary` to 2-5 sentences.",
+        "- Use short bullet-like strings for arrays.",
+        "- Add only stable, reusable claims and concepts; skip filler prose.",
+        "- Use `cross_refs` for chunk files or batch ids that should be revisited together.",
+        "- Leave `status` as `completed` once the note is usable.",
+        "",
+        "## Required JSON shape",
+        "",
+        "```json",
+        json.dumps(note_template(batch), ensure_ascii=False, indent=2),
+        "```",
+        "",
+        "## Source chunks",
+        "",
+    ]
+    for chunk_file, chunk_title in zip(batch.chunk_files, batch.chunk_titles):
+        chunk_text = (chunk_dir / chunk_file).read_text(encoding="utf-8")
+        lines.extend(
+            [
+                f"### {chunk_title} ({chunk_file})",
+                "",
+                "```markdown",
+                chunk_text.rstrip(),
+                "```",
+                "",
+            ]
+        )
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def prepare_run(
+    source: Path,
+    out_dir: Path,
+    level: int,
+    max_chunk_words: int,
+    max_batch_words: int,
+    max_chunks_per_batch: int,
+    prefix: str,
+    force_resplit: bool = False,
+) -> dict:
+    out_dir.mkdir(parents=True, exist_ok=True)
+    chunks_dir = out_dir / "chunks"
+    batch_packets_dir = out_dir / "batch-packets"
+    batch_notes_dir = out_dir / "batch-notes"
+    batch_packets_dir.mkdir(exist_ok=True)
+    batch_notes_dir.mkdir(exist_ok=True)
+
+    manifest, effective_level, source_title = prepare_chunks(
+        source, chunks_dir, level, max_chunk_words, prefix, force_resplit
+    )
+    batches = plan_batches(manifest, max_batch_words, max_chunks_per_batch)
+    write_json(
+        out_dir / "batch-plan.json",
+        {
+            "source": str(source),
+            "source_title": source_title,
+            "generated_at": now_iso(),
+            "effective_split_level": effective_level,
+            "max_chunk_words": max_chunk_words,
+            "max_batch_words": max_batch_words,
+            "max_chunks_per_batch": max_chunks_per_batch,
+            "batches": [batch.__dict__ for batch in batches],
+        },
+    )
+
+    notes_by_batch: dict[str, CompletedNote] = {}
+    for batch in batches:
+        note_path = batch_notes_dir / f"{batch.batch_id}.json"
+        if not note_path.exists():
+            write_json(note_path, note_template(batch))
+        note = load_completed_note(note_path)
+        if note is not None:
+            notes_by_batch[batch.batch_id] = note
+
+    completed_before_current: list[CompletedNote] = []
+    batch_rows = []
+    for idx, batch in enumerate(batches, start=1):
+        note_path = batch_notes_dir / f"{batch.batch_id}.json"
+        snapshot = build_rolling_snapshot(completed_before_current)
+        packet_text = render_packet(
+            batch,
+            source_title,
+            idx,
+            len(batches),
+            chunks_dir,
+            note_path,
+            snapshot,
+        )
+        packet_path = batch_packets_dir / f"{batch.batch_id}.md"
+        packet_path.write_text(packet_text, encoding="utf-8")
+
+        status = "completed" if batch.batch_id in notes_by_batch else "pending"
+        batch_rows.append(
+            {
+                "batch_id": batch.batch_id,
+                "status": status,
+                "chapter_key": batch.chapter_key,
+                "chunk_files": batch.chunk_files,
+                "chunk_titles": batch.chunk_titles,
+                "total_words": batch.total_words,
+                "note_file": str(note_path.relative_to(out_dir)),
+                "packet_file": str(packet_path.relative_to(out_dir)),
+            }
+        )
+        if batch.batch_id in notes_by_batch:
+            completed_before_current.append(notes_by_batch[batch.batch_id])
+
+    completed_notes = [
+        notes_by_batch[row["batch_id"]]
+        for row in batch_rows
+        if row["batch_id"] in notes_by_batch
+    ]
+    snapshot = build_rolling_snapshot(completed_notes)
+    completed_chunks = sum(
+        len(row["chunk_files"]) for row in batch_rows if row["status"] == "completed"
+    )
+    reading_state = {
+        "source": str(source),
+        "source_title": source_title,
+        "generated_at": now_iso(),
+        "effective_split_level": effective_level,
+        "batch_count": len(batch_rows),
+        "completed_batches": len(completed_notes),
+        "pending_batches": len(batch_rows) - len(completed_notes),
+        "completed_chunks": completed_chunks,
+        "snapshot": snapshot,
+        "batches": batch_rows,
+    }
+    write_json(out_dir / "reading-state.json", reading_state)
+
+    index_lines = [
+        "# Close Reading Run",
+        "",
+        f"- Source: `{source}`",
+        f"- Source title: {source_title}",
+        f"- Effective split level: H{effective_level}",
+        f"- Batches: {len(batch_rows)}",
+        f"- Completed batches: {len(completed_notes)}",
+        "",
+        "## Batch queue",
+        "",
+    ]
+    for row in batch_rows:
+        index_lines.append(
+            f"- **{row['batch_id']}** [{row['status']}] — {row['chapter_key']} "
+            f"({len(row['chunk_files'])} chunks, {row['total_words']} words)"
+        )
+    (out_dir / "README.md").write_text("\n".join(index_lines) + "\n", encoding="utf-8")
+    return reading_state
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Prepare a chunked close-reading harness for oversized markdown sources."
+    )
+    parser.add_argument("source", help="Path to the source markdown file")
+    parser.add_argument(
+        "--out", required=True, help="Output directory for the close-reading run"
+    )
+    parser.add_argument(
+        "--level",
+        type=int,
+        default=2,
+        help="Preferred heading level for chunking (default: 2)",
+    )
+    parser.add_argument(
+        "--max-chunk-words",
+        type=int,
+        default=1800,
+        help="Maximum words per chunk before recursive re-splitting (default: 1800)",
+    )
+    parser.add_argument(
+        "--max-batch-words",
+        type=int,
+        default=4800,
+        help="Maximum total words per close-reading batch (default: 4800)",
+    )
+    parser.add_argument(
+        "--max-chunks-per-batch",
+        type=int,
+        default=4,
+        help="Maximum chunks included in one batch packet (default: 4)",
+    )
+    parser.add_argument(
+        "--prefix", default="", help="Optional filename prefix for chunk files"
+    )
+    parser.add_argument(
+        "--force-resplit",
+        action="store_true",
+        help="Rebuild chunks even if an existing manifest already exists",
+    )
+    args = parser.parse_args()
+
+    state = prepare_run(
+        source=Path(args.source),
+        out_dir=Path(args.out),
+        level=args.level,
+        max_chunk_words=args.max_chunk_words,
+        max_batch_words=args.max_batch_words,
+        max_chunks_per_batch=args.max_chunks_per_batch,
+        prefix=args.prefix,
+        force_resplit=args.force_resplit,
+    )
+    print(json.dumps(state, ensure_ascii=False))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/knowledge-base-ingest/scripts/synthesize_knowledge.py
+++ b/skills/knowledge-base-ingest/scripts/synthesize_knowledge.py
@@ -1,0 +1,251 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from collections import Counter, defaultdict
+from datetime import datetime
+from pathlib import Path
+
+from split_markdown import slugify
+
+NOTE_LIST_FIELDS = [
+    "key_claims",
+    "concepts",
+    "procedures",
+    "entities",
+    "open_questions",
+    "cross_refs",
+    "candidate_topics",
+]
+
+
+def now_iso() -> str:
+    return datetime.now().replace(microsecond=0).isoformat()
+
+
+def read_json(path: Path):
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def write_text(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def normalize_list(value) -> list[str]:
+    if isinstance(value, str):
+        value = [value]
+    if not isinstance(value, list):
+        return []
+    normalized = []
+    for item in value:
+        if not isinstance(item, str):
+            continue
+        text = " ".join(item.split()).strip()
+        if text:
+            normalized.append(text)
+    return normalized
+
+
+def load_completed_notes(run_dir: Path, batch_rows: list[dict]) -> dict[str, dict]:
+    notes = {}
+    for row in batch_rows:
+        note_file = row.get("note_file", f"batch-notes/{row['batch_id']}.json")
+        note_path = run_dir / note_file
+        if not note_path.exists():
+            continue
+        payload = read_json(note_path)
+        summary = " ".join(str(payload.get("summary", "")).split()).strip()
+        lists = {
+            field: normalize_list(payload.get(field, [])) for field in NOTE_LIST_FIELDS
+        }
+        meaningful = summary or any(lists[field] for field in NOTE_LIST_FIELDS)
+        if not meaningful:
+            continue
+        notes[row["batch_id"]] = {
+            "summary": summary,
+            **lists,
+        }
+    return notes
+
+
+def build_synthesis(run_dir: Path, out_dir: Path) -> dict:
+    plan = read_json(run_dir / "batch-plan.json")
+    batches = plan["batches"]
+    notes = load_completed_notes(run_dir, batches)
+
+    concept_counter: Counter[str] = Counter()
+    entity_counter: Counter[str] = Counter()
+    topic_counter: Counter[str] = Counter()
+    question_counter: Counter[str] = Counter()
+    claim_counter: Counter[str] = Counter()
+    procedure_counter: Counter[str] = Counter()
+    chapter_rows: dict[str, dict] = defaultdict(
+        lambda: {
+            "batches": [],
+            "summaries": [],
+            "claims": [],
+            "procedures": [],
+            "topics": [],
+        }
+    )
+
+    for row in batches:
+        chapter = row["chapter_key"]
+        chapter_rows[chapter]["batches"].append(row["batch_id"])
+        note = notes.get(row["batch_id"])
+        if not note:
+            continue
+        if note["summary"]:
+            chapter_rows[chapter]["summaries"].append(note["summary"])
+        chapter_rows[chapter]["claims"].extend(note["key_claims"])
+        chapter_rows[chapter]["procedures"].extend(note["procedures"])
+        chapter_rows[chapter]["topics"].extend(note["candidate_topics"])
+        concept_counter.update(note["concepts"])
+        entity_counter.update(note["entities"])
+        topic_counter.update(note["candidate_topics"])
+        question_counter.update(note["open_questions"])
+        claim_counter.update(note["key_claims"])
+        procedure_counter.update(note["procedures"])
+
+    source_title = plan["source_title"]
+
+    overview_lines = [
+        f"# Source Overview — {source_title}",
+        "",
+        f"- Generated at: {now_iso()}",
+        f"- Source path: `{plan['source']}`",
+        f"- Effective split level: H{plan['effective_split_level']}",
+        f"- Total batches: {len(batches)}",
+        f"- Completed notes: {len(notes)}",
+        "",
+        "## What this synthesis gives you",
+        "",
+        "- a source overview baseline",
+        "- chapter-level summaries from completed close-reading batches",
+        "- topic/glossary seeds worth promoting into stable pages",
+        "- unresolved questions to revisit before final import",
+        "",
+        "## Strongest repeated concepts",
+        "",
+    ]
+    for term, count in concept_counter.most_common(12):
+        overview_lines.append(f"- **{term}** (x{count})")
+    if not concept_counter:
+        overview_lines.append("- none yet")
+
+    overview_lines.extend(["", "## Candidate page map", ""])
+    overview_lines.append(
+        f"- `overview-{slugify(source_title)}.md` — source overview / ingest rules / lineage"
+    )
+    for chapter in chapter_rows:
+        overview_lines.append(
+            f"- `knowledge-{slugify(chapter)}.md` — chapter summary / links / extracted knowledge"
+        )
+    for term, _ in topic_counter.most_common(10):
+        overview_lines.append(
+            f"- `knowledge-{slugify(term)}.md` — candidate topic page"
+        )
+    write_text(out_dir / "source-overview.md", "\n".join(overview_lines) + "\n")
+
+    chapter_lines = ["# Chapter Summaries", ""]
+    for chapter, payload in chapter_rows.items():
+        chapter_lines.extend([f"## {chapter}", ""])
+        chapter_lines.append(f"- Batches: {', '.join(payload['batches'])}")
+        if payload["summaries"]:
+            chapter_lines.append("- Summaries:")
+            for summary in payload["summaries"]:
+                chapter_lines.append(f"  - {summary}")
+        else:
+            chapter_lines.append("- Summaries: pending")
+        if payload["claims"]:
+            chapter_lines.append("- Repeated claims:")
+            for claim in payload["claims"][:8]:
+                chapter_lines.append(f"  - {claim}")
+        if payload["procedures"]:
+            chapter_lines.append("- Procedures:")
+            for item in payload["procedures"][:8]:
+                chapter_lines.append(f"  - {item}")
+        chapter_lines.append("")
+    write_text(out_dir / "chapter-summaries.md", "\n".join(chapter_lines) + "\n")
+
+    topic_lines = ["# Topic Candidates", ""]
+    for term, count in topic_counter.most_common(20):
+        topic_lines.append(f"- **{term}** (x{count})")
+    if not topic_counter:
+        topic_lines.append("- none yet")
+    write_text(out_dir / "topic-candidates.md", "\n".join(topic_lines) + "\n")
+
+    glossary_lines = ["# Glossary Seeds", ""]
+    for term, count in concept_counter.most_common(25):
+        glossary_lines.append(f"- **{term}** (x{count})")
+    if not concept_counter:
+        glossary_lines.append("- none yet")
+    write_text(out_dir / "glossary-seeds.md", "\n".join(glossary_lines) + "\n")
+
+    question_lines = ["# Unresolved Questions", ""]
+    for question, count in question_counter.most_common(20):
+        question_lines.append(f"- {question} (x{count})")
+    if not question_counter:
+        question_lines.append("- none yet")
+    write_text(out_dir / "unresolved-questions.md", "\n".join(question_lines) + "\n")
+
+    report = {
+        "generated_at": now_iso(),
+        "source_title": source_title,
+        "batch_count": len(batches),
+        "completed_notes": len(notes),
+        "chapters": len(chapter_rows),
+        "top_concepts": [
+            {"term": term, "count": count}
+            for term, count in concept_counter.most_common(20)
+        ],
+        "top_entities": [
+            {"term": term, "count": count}
+            for term, count in entity_counter.most_common(20)
+        ],
+        "candidate_topics": [
+            {"term": term, "count": count}
+            for term, count in topic_counter.most_common(20)
+        ],
+        "open_questions": [
+            {"question": question, "count": count}
+            for question, count in question_counter.most_common(20)
+        ],
+        "repeated_claims": [
+            {"claim": claim, "count": count}
+            for claim, count in claim_counter.most_common(20)
+        ],
+        "procedures": [
+            {"procedure": item, "count": count}
+            for item, count in procedure_counter.most_common(20)
+        ],
+    }
+    write_text(
+        out_dir / "synthesis-report.json",
+        json.dumps(report, ensure_ascii=False, indent=2) + "\n",
+    )
+    return report
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Synthesize completed close-reading batch notes into knowledge-base candidates."
+    )
+    parser.add_argument("run_dir", help="Directory produced by close_read_markdown.py")
+    parser.add_argument(
+        "--out",
+        help="Output directory for synthesis artifacts (default: <run_dir>/synthesis)",
+    )
+    args = parser.parse_args()
+
+    run_dir = Path(args.run_dir)
+    out_dir = Path(args.out) if args.out else run_dir / "synthesis"
+    report = build_synthesis(run_dir, out_dir)
+    print(json.dumps(report, ensure_ascii=False))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/knowledge-base-ingest/scripts/synthesize_knowledge.py
+++ b/skills/knowledge-base-ingest/scripts/synthesize_knowledge.py
@@ -33,6 +33,10 @@ def write_text(path: Path, content: str) -> None:
     path.write_text(content, encoding="utf-8")
 
 
+def yaml_quote(value: str) -> str:
+    return json.dumps(value, ensure_ascii=False)
+
+
 def normalize_list(value) -> list[str]:
     if isinstance(value, str):
         value = [value]
@@ -83,7 +87,65 @@ def dedupe(items: list[str]) -> list[str]:
     return result
 
 
-def build_synthesis(run_dir: Path, out_dir: Path) -> dict:
+def frontmatter_block(meta: dict) -> str:
+    lines = ["---"]
+    for key, value in meta.items():
+        if value is None:
+            continue
+        if isinstance(value, bool):
+            rendered = "true" if value else "false"
+        elif isinstance(value, list):
+            rendered = "[" + ", ".join(yaml_quote(str(item)) for item in value) + "]"
+        else:
+            rendered = yaml_quote(str(value))
+        lines.append(f"{key}: {rendered}")
+    lines.append("---")
+    return "\n".join(lines)
+
+
+def build_page_frontmatter(
+    *,
+    title: str,
+    page_type: str,
+    area: str,
+    tags: list[str],
+    status: str,
+    source_title: str,
+    source_path: str,
+    source_hash: str,
+    generated_at: str,
+    run_name: str,
+    candidate_kind: str,
+    owner: str | None = None,
+) -> str:
+    return frontmatter_block(
+        {
+            "title": title,
+            "type": page_type,
+            "area": area,
+            "tags": tags,
+            "status": status,
+            "owner": owner,
+            "candidate": True,
+            "candidate_kind": candidate_kind,
+            "candidate_run": run_name,
+            "source_title": source_title,
+            "source_path": source_path,
+            "source_hash": source_hash,
+            "generated_at": generated_at,
+            "updated": generated_at[:10],
+        }
+    )
+
+
+def build_synthesis(
+    run_dir: Path,
+    out_dir: Path,
+    *,
+    default_area: str = "__SET_ME__",
+    owner: str | None = None,
+    status: str = "draft",
+) -> dict:
     plan = read_json(run_dir / "batch-plan.json")
     batches = plan["batches"]
     notes = load_completed_notes(run_dir, batches)
@@ -129,6 +191,7 @@ def build_synthesis(run_dir: Path, out_dir: Path) -> dict:
 
     source_title = plan["source_title"]
     source_slug = slugify(source_title)
+    generated_at = now_iso()
     candidate_pages_dir = out_dir / "candidate-pages"
     candidate_pages_dir.mkdir(parents=True, exist_ok=True)
 
@@ -143,18 +206,49 @@ def build_synthesis(run_dir: Path, out_dir: Path) -> dict:
     }
 
     link_map: dict[str, dict] = {}
+    area_needs_confirmation = default_area == "__SET_ME__"
+    base_tags = dedupe(["candidate", "ingest", source_slug])[:3]
 
     chapter_list = list(chapter_rows.keys())
+    overview_frontmatter = build_page_frontmatter(
+        title=source_title,
+        page_type="overview",
+        area=default_area,
+        tags=base_tags + ["overview"],
+        status=status,
+        source_title=source_title,
+        source_path=plan["source"],
+        source_hash=plan.get("source_hash", ""),
+        generated_at=generated_at,
+        run_name=run_dir.name,
+        candidate_kind="overview",
+        owner=owner,
+    )
     overview_candidate_lines = [
+        overview_frontmatter,
+        "",
         f"# {source_title} — candidate overview page",
         "",
-        f"- Generated at: {now_iso()}",
+        f"- Generated at: {generated_at}",
         f"- Source path: `{plan['source']}`",
         f"- Effective split level: H{plan['effective_split_level']}",
-        "",
-        "## Chapter links",
-        "",
+        f"- Candidate status: `{status}`",
+        f"- Candidate area: `{default_area}`",
     ]
+    if area_needs_confirmation:
+        overview_candidate_lines.extend(
+            [
+                "",
+                "> `area` is still `__SET_ME__`. Confirm the vault area before promoting this page into a real knowledge base.",
+            ]
+        )
+    overview_candidate_lines.extend(
+        [
+            "",
+            "## Chapter links",
+            "",
+        ]
+    )
     for chapter in chapter_list:
         chapter_path = chapter_candidates[chapter]
         overview_candidate_lines.append(f"- [{chapter}]({chapter_path.name})")
@@ -182,10 +276,30 @@ def build_synthesis(run_dir: Path, out_dir: Path) -> dict:
             if index + 1 < len(chapter_list)
             else None
         )
+        chapter_frontmatter = build_page_frontmatter(
+            title=chapter,
+            page_type="knowledge",
+            area=default_area,
+            tags=dedupe(
+                base_tags + ["chapter"] + [slugify(topic) for topic in topic_names[:4]]
+            ),
+            status=status,
+            source_title=source_title,
+            source_path=plan["source"],
+            source_hash=plan.get("source_hash", ""),
+            generated_at=generated_at,
+            run_name=run_dir.name,
+            candidate_kind="chapter",
+            owner=owner,
+        )
         lines = [
+            chapter_frontmatter,
+            "",
             f"# {chapter}",
             "",
             f"- Source overview: [{overview_candidate.name}]({overview_candidate.name})",
+            f"- Candidate status: `{status}`",
+            f"- Candidate area: `{default_area}`",
         ]
         if prev_path:
             lines.append(f"- Previous chapter: [{prev_path}]({prev_path})")
@@ -233,10 +347,28 @@ def build_synthesis(run_dir: Path, out_dir: Path) -> dict:
                 if other != topic and other in topic_candidates
             )
         sibling_topics = dedupe(sibling_topics)[:6]
+        topic_frontmatter = build_page_frontmatter(
+            title=topic,
+            page_type="knowledge",
+            area=default_area,
+            tags=dedupe(base_tags + ["topic", slugify(topic)]),
+            status=status,
+            source_title=source_title,
+            source_path=plan["source"],
+            source_hash=plan.get("source_hash", ""),
+            generated_at=generated_at,
+            run_name=run_dir.name,
+            candidate_kind="topic",
+            owner=owner,
+        )
         lines = [
+            topic_frontmatter,
+            "",
             f"# {topic}",
             "",
             f"- Source overview: [{overview_candidate.name}]({overview_candidate.name})",
+            f"- Candidate status: `{status}`",
+            f"- Candidate area: `{default_area}`",
             "",
             "## Mentioned in chapters",
             "",
@@ -263,12 +395,13 @@ def build_synthesis(run_dir: Path, out_dir: Path) -> dict:
     overview_lines = [
         f"# Source Overview — {source_title}",
         "",
-        f"- Generated at: {now_iso()}",
+        f"- Generated at: {generated_at}",
         f"- Source path: `{plan['source']}`",
         f"- Effective split level: H{plan['effective_split_level']}",
         f"- Total batches: {len(batches)}",
         f"- Completed notes: {len(notes)}",
         f"- Candidate overview page: [{overview_candidate.name}](candidate-pages/{overview_candidate.name})",
+        f"- Default candidate area: `{default_area}`",
         "",
         "## What this synthesis gives you",
         "",
@@ -384,11 +517,16 @@ def build_synthesis(run_dir: Path, out_dir: Path) -> dict:
     write_text(out_dir / "candidate-link-map.md", "\n".join(link_map_lines) + "\n")
 
     report = {
-        "generated_at": now_iso(),
+        "generated_at": generated_at,
         "source_title": source_title,
         "batch_count": len(batches),
         "completed_notes": len(notes),
         "chapters": len(chapter_rows),
+        "candidate_metadata": {
+            "default_area": default_area,
+            "status": status,
+            "owner": owner,
+        },
         "candidate_pages": {
             "overview": overview_candidate.name,
             "chapters": [path.name for path in chapter_candidates.values()],
@@ -435,11 +573,31 @@ def main() -> int:
         "--out",
         help="Output directory for synthesis artifacts (default: <run_dir>/synthesis)",
     )
+    parser.add_argument(
+        "--default-area",
+        default="__SET_ME__",
+        help="Area value to write into candidate page frontmatter (default: __SET_ME__)",
+    )
+    parser.add_argument(
+        "--owner",
+        help="Optional owner value to write into candidate page frontmatter",
+    )
+    parser.add_argument(
+        "--status",
+        default="draft",
+        help="Status value to write into candidate page frontmatter (default: draft)",
+    )
     args = parser.parse_args()
 
     run_dir = Path(args.run_dir)
     out_dir = Path(args.out) if args.out else run_dir / "synthesis"
-    report = build_synthesis(run_dir, out_dir)
+    report = build_synthesis(
+        run_dir,
+        out_dir,
+        default_area=args.default_area,
+        owner=args.owner,
+        status=args.status,
+    )
     print(json.dumps(report, ensure_ascii=False))
     return 0
 

--- a/skills/knowledge-base-ingest/scripts/synthesize_knowledge.py
+++ b/skills/knowledge-base-ingest/scripts/synthesize_knowledge.py
@@ -194,6 +194,8 @@ def build_synthesis(
     generated_at = now_iso()
     candidate_pages_dir = out_dir / "candidate-pages"
     candidate_pages_dir.mkdir(parents=True, exist_ok=True)
+    for stale_page in candidate_pages_dir.glob("*.md"):
+        stale_page.unlink()
 
     overview_candidate = candidate_pages_dir / f"overview-{source_slug}.md"
     chapter_candidates = {

--- a/skills/knowledge-base-ingest/scripts/synthesize_knowledge.py
+++ b/skills/knowledge-base-ingest/scripts/synthesize_knowledge.py
@@ -51,23 +51,36 @@ def normalize_list(value) -> list[str]:
 def load_completed_notes(run_dir: Path, batch_rows: list[dict]) -> dict[str, dict]:
     notes = {}
     for row in batch_rows:
-        note_file = row.get("note_file", f"batch-notes/{row['batch_id']}.json")
+        note_file = row.get("note_file", f"batch-notes/{row['batch_key']}.json")
         note_path = run_dir / note_file
         if not note_path.exists():
             continue
         payload = read_json(note_path)
         summary = " ".join(str(payload.get("summary", "")).split()).strip()
+        status = str(payload.get("status", "pending")).strip().lower() or "pending"
         lists = {
             field: normalize_list(payload.get(field, [])) for field in NOTE_LIST_FIELDS
         }
         meaningful = summary or any(lists[field] for field in NOTE_LIST_FIELDS)
-        if not meaningful:
+        if not meaningful or status != "completed":
             continue
-        notes[row["batch_id"]] = {
+        notes[row["batch_key"]] = {
             "summary": summary,
+            "status": status,
+            "batch_id": payload.get("batch_id", row.get("batch_id", row["batch_key"])),
             **lists,
         }
     return notes
+
+
+def dedupe(items: list[str]) -> list[str]:
+    seen = set()
+    result = []
+    for item in items:
+        if item not in seen:
+            seen.add(item)
+            result.append(item)
+    return result
 
 
 def build_synthesis(run_dir: Path, out_dir: Path) -> dict:
@@ -88,13 +101,15 @@ def build_synthesis(run_dir: Path, out_dir: Path) -> dict:
             "claims": [],
             "procedures": [],
             "topics": [],
+            "cross_refs": [],
         }
     )
+    topic_to_chapters: dict[str, set[str]] = defaultdict(set)
 
     for row in batches:
         chapter = row["chapter_key"]
         chapter_rows[chapter]["batches"].append(row["batch_id"])
-        note = notes.get(row["batch_id"])
+        note = notes.get(row["batch_key"])
         if not note:
             continue
         if note["summary"]:
@@ -102,14 +117,148 @@ def build_synthesis(run_dir: Path, out_dir: Path) -> dict:
         chapter_rows[chapter]["claims"].extend(note["key_claims"])
         chapter_rows[chapter]["procedures"].extend(note["procedures"])
         chapter_rows[chapter]["topics"].extend(note["candidate_topics"])
+        chapter_rows[chapter]["cross_refs"].extend(note["cross_refs"])
         concept_counter.update(note["concepts"])
         entity_counter.update(note["entities"])
         topic_counter.update(note["candidate_topics"])
         question_counter.update(note["open_questions"])
         claim_counter.update(note["key_claims"])
         procedure_counter.update(note["procedures"])
+        for topic in note["candidate_topics"]:
+            topic_to_chapters[topic].add(chapter)
 
     source_title = plan["source_title"]
+    source_slug = slugify(source_title)
+    candidate_pages_dir = out_dir / "candidate-pages"
+    candidate_pages_dir.mkdir(parents=True, exist_ok=True)
+
+    overview_candidate = candidate_pages_dir / f"overview-{source_slug}.md"
+    chapter_candidates = {
+        chapter: candidate_pages_dir / f"knowledge-{slugify(chapter)}.md"
+        for chapter in chapter_rows
+    }
+    topic_candidates = {
+        topic: candidate_pages_dir / f"knowledge-{slugify(topic)}.md"
+        for topic, _ in topic_counter.most_common(20)
+    }
+
+    link_map: dict[str, dict] = {}
+
+    chapter_list = list(chapter_rows.keys())
+    overview_candidate_lines = [
+        f"# {source_title} — candidate overview page",
+        "",
+        f"- Generated at: {now_iso()}",
+        f"- Source path: `{plan['source']}`",
+        f"- Effective split level: H{plan['effective_split_level']}",
+        "",
+        "## Chapter links",
+        "",
+    ]
+    for chapter in chapter_list:
+        chapter_path = chapter_candidates[chapter]
+        overview_candidate_lines.append(f"- [{chapter}]({chapter_path.name})")
+    overview_candidate_lines.extend(["", "## Topic links", ""])
+    for topic, path in topic_candidates.items():
+        overview_candidate_lines.append(f"- [{topic}]({path.name})")
+    write_text(overview_candidate, "\n".join(overview_candidate_lines) + "\n")
+    link_map[overview_candidate.name] = {
+        "type": "overview",
+        "links": [chapter_candidates[chapter].name for chapter in chapter_list]
+        + [path.name for path in topic_candidates.values()],
+    }
+
+    for index, chapter in enumerate(chapter_list):
+        chapter_path = chapter_candidates[chapter]
+        payload = chapter_rows[chapter]
+        topic_names = [
+            topic for topic in dedupe(payload["topics"]) if topic in topic_candidates
+        ]
+        prev_path = (
+            chapter_candidates[chapter_list[index - 1]].name if index > 0 else None
+        )
+        next_path = (
+            chapter_candidates[chapter_list[index + 1]].name
+            if index + 1 < len(chapter_list)
+            else None
+        )
+        lines = [
+            f"# {chapter}",
+            "",
+            f"- Source overview: [{overview_candidate.name}]({overview_candidate.name})",
+        ]
+        if prev_path:
+            lines.append(f"- Previous chapter: [{prev_path}]({prev_path})")
+        if next_path:
+            lines.append(f"- Next chapter: [{next_path}]({next_path})")
+        lines.extend(["", "## Batch summaries", ""])
+        if payload["summaries"]:
+            for summary in payload["summaries"]:
+                lines.append(f"- {summary}")
+        else:
+            lines.append("- pending")
+        lines.extend(["", "## Related topic candidates", ""])
+        if topic_names:
+            for topic in topic_names:
+                lines.append(f"- [{topic}]({topic_candidates[topic].name})")
+        else:
+            lines.append("- none yet")
+        lines.extend(["", "## Cross refs worth revisiting", ""])
+        if payload["cross_refs"]:
+            for ref in dedupe(payload["cross_refs"])[:10]:
+                lines.append(f"- `{ref}`")
+        else:
+            lines.append("- none yet")
+        write_text(chapter_path, "\n".join(lines) + "\n")
+        links = [overview_candidate.name]
+        if prev_path:
+            links.append(prev_path)
+        if next_path:
+            links.append(next_path)
+        links.extend(topic_candidates[topic].name for topic in topic_names)
+        link_map[chapter_path.name] = {"type": "chapter", "links": links}
+
+    topic_chapter_lists = {
+        topic: sorted(chapters)
+        for topic, chapters in topic_to_chapters.items()
+        if topic in topic_candidates
+    }
+    for topic, path in topic_candidates.items():
+        chapters = topic_chapter_lists.get(topic, [])
+        sibling_topics = []
+        for chapter in chapters:
+            sibling_topics.extend(
+                other
+                for other in dedupe(chapter_rows[chapter]["topics"])
+                if other != topic and other in topic_candidates
+            )
+        sibling_topics = dedupe(sibling_topics)[:6]
+        lines = [
+            f"# {topic}",
+            "",
+            f"- Source overview: [{overview_candidate.name}]({overview_candidate.name})",
+            "",
+            "## Mentioned in chapters",
+            "",
+        ]
+        if chapters:
+            for chapter in chapters:
+                lines.append(f"- [{chapter}]({chapter_candidates[chapter].name})")
+        else:
+            lines.append("- none yet")
+        lines.extend(["", "## Neighbor topics", ""])
+        if sibling_topics:
+            for sibling in sibling_topics:
+                lines.append(f"- [{sibling}]({topic_candidates[sibling].name})")
+        else:
+            lines.append("- none yet")
+        write_text(path, "\n".join(lines) + "\n")
+        link_map[path.name] = {
+            "type": "topic",
+            "links": [overview_candidate.name]
+            + [chapter_candidates[chapter].name for chapter in chapters]
+            + [topic_candidates[sibling].name for sibling in sibling_topics],
+        }
 
     overview_lines = [
         f"# Source Overview — {source_title}",
@@ -119,6 +268,7 @@ def build_synthesis(run_dir: Path, out_dir: Path) -> dict:
         f"- Effective split level: H{plan['effective_split_level']}",
         f"- Total batches: {len(batches)}",
         f"- Completed notes: {len(notes)}",
+        f"- Candidate overview page: [{overview_candidate.name}](candidate-pages/{overview_candidate.name})",
         "",
         "## What this synthesis gives you",
         "",
@@ -126,6 +276,7 @@ def build_synthesis(run_dir: Path, out_dir: Path) -> dict:
         "- chapter-level summaries from completed close-reading batches",
         "- topic/glossary seeds worth promoting into stable pages",
         "- unresolved questions to revisit before final import",
+        "- candidate draft pages with explicit relative links",
         "",
         "## Strongest repeated concepts",
         "",
@@ -134,24 +285,26 @@ def build_synthesis(run_dir: Path, out_dir: Path) -> dict:
         overview_lines.append(f"- **{term}** (x{count})")
     if not concept_counter:
         overview_lines.append("- none yet")
-
     overview_lines.extend(["", "## Candidate page map", ""])
     overview_lines.append(
-        f"- `overview-{slugify(source_title)}.md` — source overview / ingest rules / lineage"
+        f"- [candidate-pages/{overview_candidate.name}](candidate-pages/{overview_candidate.name})"
     )
-    for chapter in chapter_rows:
+    for chapter in chapter_list:
+        path = chapter_candidates[chapter]
         overview_lines.append(
-            f"- `knowledge-{slugify(chapter)}.md` — chapter summary / links / extracted knowledge"
+            f"- [{path.name}](candidate-pages/{path.name}) — chapter summary draft"
         )
-    for term, _ in topic_counter.most_common(10):
+    for topic, path in topic_candidates.items():
         overview_lines.append(
-            f"- `knowledge-{slugify(term)}.md` — candidate topic page"
+            f"- [{path.name}](candidate-pages/{path.name}) — topic draft for {topic}"
         )
     write_text(out_dir / "source-overview.md", "\n".join(overview_lines) + "\n")
 
     chapter_lines = ["# Chapter Summaries", ""]
     for chapter, payload in chapter_rows.items():
-        chapter_lines.extend([f"## {chapter}", ""])
+        chapter_lines.extend(
+            [f"## [{chapter}](candidate-pages/{chapter_candidates[chapter].name})", ""]
+        )
         chapter_lines.append(f"- Batches: {', '.join(payload['batches'])}")
         if payload["summaries"]:
             chapter_lines.append("- Summaries:")
@@ -161,18 +314,29 @@ def build_synthesis(run_dir: Path, out_dir: Path) -> dict:
             chapter_lines.append("- Summaries: pending")
         if payload["claims"]:
             chapter_lines.append("- Repeated claims:")
-            for claim in payload["claims"][:8]:
+            for claim in dedupe(payload["claims"])[:8]:
                 chapter_lines.append(f"  - {claim}")
         if payload["procedures"]:
             chapter_lines.append("- Procedures:")
-            for item in payload["procedures"][:8]:
+            for item in dedupe(payload["procedures"])[:8]:
                 chapter_lines.append(f"  - {item}")
+        if payload["topics"]:
+            chapter_lines.append("- Topic links:")
+            for topic in dedupe(payload["topics"]):
+                if topic in topic_candidates:
+                    chapter_lines.append(
+                        f"  - [{topic}](candidate-pages/{topic_candidates[topic].name})"
+                    )
         chapter_lines.append("")
     write_text(out_dir / "chapter-summaries.md", "\n".join(chapter_lines) + "\n")
 
     topic_lines = ["# Topic Candidates", ""]
     for term, count in topic_counter.most_common(20):
-        topic_lines.append(f"- **{term}** (x{count})")
+        path = topic_candidates.get(term)
+        if path:
+            topic_lines.append(f"- [{term}](candidate-pages/{path.name}) (x{count})")
+        else:
+            topic_lines.append(f"- **{term}** (x{count})")
     if not topic_counter:
         topic_lines.append("- none yet")
     write_text(out_dir / "topic-candidates.md", "\n".join(topic_lines) + "\n")
@@ -191,12 +355,45 @@ def build_synthesis(run_dir: Path, out_dir: Path) -> dict:
         question_lines.append("- none yet")
     write_text(out_dir / "unresolved-questions.md", "\n".join(question_lines) + "\n")
 
+    link_map_json = {
+        "overview_page": overview_candidate.name,
+        "pages": link_map,
+    }
+    write_text(
+        out_dir / "candidate-link-map.json",
+        json.dumps(link_map_json, ensure_ascii=False, indent=2) + "\n",
+    )
+    link_map_lines = [
+        "# Candidate Link Map",
+        "",
+        f"- Overview page: [candidate-pages/{overview_candidate.name}](candidate-pages/{overview_candidate.name})",
+        "",
+    ]
+    for page, payload in sorted(link_map.items()):
+        link_map_lines.append(f"## {page}")
+        link_map_lines.append(f"- Type: {payload['type']}")
+        if payload["links"]:
+            link_map_lines.append("- Outgoing links:")
+            for link in payload["links"]:
+                link_map_lines.append(
+                    f"  - [candidate-pages/{link}](candidate-pages/{link})"
+                )
+        else:
+            link_map_lines.append("- Outgoing links: none")
+        link_map_lines.append("")
+    write_text(out_dir / "candidate-link-map.md", "\n".join(link_map_lines) + "\n")
+
     report = {
         "generated_at": now_iso(),
         "source_title": source_title,
         "batch_count": len(batches),
         "completed_notes": len(notes),
         "chapters": len(chapter_rows),
+        "candidate_pages": {
+            "overview": overview_candidate.name,
+            "chapters": [path.name for path in chapter_candidates.values()],
+            "topics": [path.name for path in topic_candidates.values()],
+        },
         "top_concepts": [
             {"term": term, "count": count}
             for term, count in concept_counter.most_common(20)

--- a/tests/test_close_read_markdown.py
+++ b/tests/test_close_read_markdown.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""Tests for close_read_markdown.py script."""
+
+import sys
+import json
+import tempfile
+from pathlib import Path
+
+# Add scripts directory to path
+scripts_dir = (
+    Path(__file__).parent.parent / "skills" / "knowledge-base-ingest" / "scripts"
+)
+sys.path.insert(0, str(scripts_dir))
+
+from close_read_markdown import prepare_run  # noqa: E402
+
+
+def make_source(path: Path) -> None:
+    path.write_text(
+        """# Sample Handbook
+
+## Chapter 1
+
+Intro text. Intro text. Intro text.
+
+### Section 1.1
+
+Alpha beta gamma. Alpha beta gamma. Alpha beta gamma.
+
+### Section 1.2
+
+Delta epsilon zeta. Delta epsilon zeta. Delta epsilon zeta.
+
+## Chapter 2
+
+Bridge text.
+
+### Section 2.1
+
+Theta iota kappa. Theta iota kappa. Theta iota kappa.
+""",
+        encoding="utf-8",
+    )
+
+
+def test_prepare_run_creates_packets_and_state():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        source = tmp / "source.md"
+        out = tmp / "run"
+        make_source(source)
+
+        state = prepare_run(
+            source=source,
+            out_dir=out,
+            level=2,
+            max_chunk_words=80,
+            max_batch_words=60,
+            max_chunks_per_batch=2,
+            prefix="book-",
+        )
+
+        assert state["batch_count"] >= 2
+        assert (out / "batch-plan.json").exists()
+        assert (out / "reading-state.json").exists()
+        assert (out / "batch-packets" / "batch-001.md").exists()
+        assert (out / "batch-notes" / "batch-001.json").exists()
+
+        note_payload = json.loads(
+            (out / "batch-notes" / "batch-001.json").read_text(encoding="utf-8")
+        )
+        assert note_payload["status"] == "pending"
+        assert note_payload["batch_id"] == "batch-001"
+
+
+def test_prepare_run_refreshes_rolling_state_from_completed_notes():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        source = tmp / "source.md"
+        out = tmp / "run"
+        make_source(source)
+
+        prepare_run(
+            source=source,
+            out_dir=out,
+            level=2,
+            max_chunk_words=80,
+            max_batch_words=60,
+            max_chunks_per_batch=2,
+            prefix="book-",
+        )
+
+        note = {
+            "batch_id": "batch-001",
+            "status": "completed",
+            "summary": "The first batch defines Alpha as the core concept.",
+            "key_claims": ["Alpha governs the first chapter."],
+            "concepts": ["Alpha", "Core concept"],
+            "procedures": ["Read section 1.1 before section 1.2"],
+            "entities": ["Sample Handbook"],
+            "open_questions": ["How does Chapter 2 refine Alpha?"],
+            "cross_refs": ["book-section-2-1.md"],
+            "candidate_topics": ["Alpha"],
+        }
+        (out / "batch-notes" / "batch-001.json").write_text(
+            json.dumps(note, ensure_ascii=False, indent=2), encoding="utf-8"
+        )
+
+        state = prepare_run(
+            source=source,
+            out_dir=out,
+            level=2,
+            max_chunk_words=80,
+            max_batch_words=60,
+            max_chunks_per_batch=2,
+            prefix="book-",
+        )
+
+        assert state["completed_batches"] == 1
+        assert (
+            state["snapshot"]["latest_summary"]
+            == "The first batch defines Alpha as the core concept."
+        )
+        assert state["snapshot"]["top_concepts"][0]["term"] == "Alpha"
+
+        second_packet = (out / "batch-packets" / "batch-002.md").read_text(
+            encoding="utf-8"
+        )
+        assert "The first batch defines Alpha as the core concept." in second_packet
+        assert "Alpha (x1)" in second_packet

--- a/tests/test_close_read_markdown.py
+++ b/tests/test_close_read_markdown.py
@@ -155,3 +155,20 @@ def test_prepare_run_preserves_unchanged_batches_and_resets_changed_ones():
         ).read_text(encoding="utf-8")
         assert "The first batch defines Alpha as the core concept." in second_packet
         assert "Alpha (x1)" in second_packet
+
+        original = source.read_text(encoding="utf-8")
+        start = original.index("## Chapter 2")
+        source.write_text(original[:start], encoding="utf-8")
+        state_after_remove = prepare_run(
+            source=source,
+            out_dir=out,
+            level=2,
+            max_chunk_words=80,
+            max_batch_words=60,
+            max_chunks_per_batch=2,
+            prefix="book-",
+        )
+        assert state_after_remove["removed_batches"] == [
+            "sample-handbook-chapter-2-b01"
+        ]
+        assert not (out / "batch-packets" / "sample-handbook-chapter-2-b01.md").exists()

--- a/tests/test_close_read_markdown.py
+++ b/tests/test_close_read_markdown.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 """Tests for close_read_markdown.py script."""
 
-import sys
 import json
+import sys
 import tempfile
 from pathlib import Path
 
@@ -15,9 +15,9 @@ sys.path.insert(0, str(scripts_dir))
 from close_read_markdown import prepare_run  # noqa: E402
 
 
-def make_source(path: Path) -> None:
+def make_source(path: Path, chapter_two_extra: str = "") -> None:
     path.write_text(
-        """# Sample Handbook
+        f"""# Sample Handbook
 
 ## Chapter 1
 
@@ -33,7 +33,7 @@ Delta epsilon zeta. Delta epsilon zeta. Delta epsilon zeta.
 
 ## Chapter 2
 
-Bridge text.
+Bridge text. {chapter_two_extra}
 
 ### Section 2.1
 
@@ -43,7 +43,7 @@ Theta iota kappa. Theta iota kappa. Theta iota kappa.
     )
 
 
-def test_prepare_run_creates_packets_and_state():
+def test_prepare_run_creates_packets_state_and_links():
     with tempfile.TemporaryDirectory() as tmpdir:
         tmp = Path(tmpdir)
         source = tmp / "source.md"
@@ -63,17 +63,23 @@ def test_prepare_run_creates_packets_and_state():
         assert state["batch_count"] >= 2
         assert (out / "batch-plan.json").exists()
         assert (out / "reading-state.json").exists()
-        assert (out / "batch-packets" / "batch-001.md").exists()
-        assert (out / "batch-notes" / "batch-001.json").exists()
+        assert (out / "README.md").exists()
+        packet = out / "batch-packets" / "sample-handbook-chapter-1-b01.md"
+        note = out / "batch-notes" / "sample-handbook-chapter-1-b01.json"
+        assert packet.exists()
+        assert note.exists()
 
-        note_payload = json.loads(
-            (out / "batch-notes" / "batch-001.json").read_text(encoding="utf-8")
-        )
+        note_payload = json.loads(note.read_text(encoding="utf-8"))
         assert note_payload["status"] == "pending"
-        assert note_payload["batch_id"] == "batch-001"
+        assert note_payload["batch_key"] == "sample-handbook-chapter-1-b01"
+        assert note_payload["batch_hash"]
+
+        packet_text = packet.read_text(encoding="utf-8")
+        assert "../batch-notes/sample-handbook-chapter-1-b01.json" in packet_text
+        assert "../chunks/001-book-chapter-1.md" in packet_text
 
 
-def test_prepare_run_refreshes_rolling_state_from_completed_notes():
+def test_prepare_run_preserves_unchanged_batches_and_resets_changed_ones():
     with tempfile.TemporaryDirectory() as tmpdir:
         tmp = Path(tmpdir)
         source = tmp / "source.md"
@@ -90,22 +96,34 @@ def test_prepare_run_refreshes_rolling_state_from_completed_notes():
             prefix="book-",
         )
 
-        note = {
-            "batch_id": "batch-001",
-            "status": "completed",
-            "summary": "The first batch defines Alpha as the core concept.",
-            "key_claims": ["Alpha governs the first chapter."],
-            "concepts": ["Alpha", "Core concept"],
-            "procedures": ["Read section 1.1 before section 1.2"],
-            "entities": ["Sample Handbook"],
-            "open_questions": ["How does Chapter 2 refine Alpha?"],
-            "cross_refs": ["book-section-2-1.md"],
-            "candidate_topics": ["Alpha"],
-        }
-        (out / "batch-notes" / "batch-001.json").write_text(
-            json.dumps(note, ensure_ascii=False, indent=2), encoding="utf-8"
+        first_note_path = out / "batch-notes" / "sample-handbook-chapter-1-b01.json"
+        second_note_path = out / "batch-notes" / "sample-handbook-chapter-2-b01.json"
+        first_note = json.loads(first_note_path.read_text(encoding="utf-8"))
+        second_note = json.loads(second_note_path.read_text(encoding="utf-8"))
+        first_note.update(
+            {
+                "status": "completed",
+                "summary": "The first batch defines Alpha as the core concept.",
+                "concepts": ["Alpha"],
+                "candidate_topics": ["Alpha"],
+            }
+        )
+        second_note.update(
+            {
+                "status": "completed",
+                "summary": "The second batch defines Gamma as a later topic.",
+                "concepts": ["Gamma"],
+                "candidate_topics": ["Gamma"],
+            }
+        )
+        first_note_path.write_text(
+            json.dumps(first_note, ensure_ascii=False, indent=2), encoding="utf-8"
+        )
+        second_note_path.write_text(
+            json.dumps(second_note, ensure_ascii=False, indent=2), encoding="utf-8"
         )
 
+        make_source(source, chapter_two_extra="Updated material changed this batch.")
         state = prepare_run(
             source=source,
             out_dir=out,
@@ -117,14 +135,23 @@ def test_prepare_run_refreshes_rolling_state_from_completed_notes():
         )
 
         assert state["completed_batches"] == 1
-        assert (
-            state["snapshot"]["latest_summary"]
-            == "The first batch defines Alpha as the core concept."
-        )
-        assert state["snapshot"]["top_concepts"][0]["term"] == "Alpha"
+        assert state["changed_batches"] == 1
+        batches = {row["batch_key"]: row for row in state["batches"]}
+        assert batches["sample-handbook-chapter-1-b01"]["status"] == "completed"
+        assert batches["sample-handbook-chapter-1-b01"]["change_status"] == "unchanged"
+        assert batches["sample-handbook-chapter-2-b01"]["status"] == "pending"
+        assert batches["sample-handbook-chapter-2-b01"]["change_status"] == "changed"
 
-        second_packet = (out / "batch-packets" / "batch-002.md").read_text(
-            encoding="utf-8"
+        archived = list(
+            (out / "stale-notes").glob("sample-handbook-chapter-2-b01--*.json")
         )
+        assert archived, "changed batch note should be archived for traceability"
+        refreshed_note = json.loads(second_note_path.read_text(encoding="utf-8"))
+        assert refreshed_note["status"] == "pending"
+        assert refreshed_note["summary"] == ""
+
+        second_packet = (
+            out / "batch-packets" / "sample-handbook-chapter-2-b01.md"
+        ).read_text(encoding="utf-8")
         assert "The first batch defines Alpha as the core concept." in second_packet
         assert "Alpha (x1)" in second_packet

--- a/tests/test_synthesize_knowledge.py
+++ b/tests/test_synthesize_knowledge.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 """Tests for synthesize_knowledge.py script."""
 
-import sys
 import json
+import sys
 import tempfile
 from pathlib import Path
 
@@ -40,7 +40,7 @@ Gamma flow. Gamma flow. Gamma flow.
     )
 
 
-def test_build_synthesis_outputs_expected_files():
+def test_build_synthesis_outputs_candidate_pages_and_link_map():
     with tempfile.TemporaryDirectory() as tmpdir:
         tmp = Path(tmpdir)
         source = tmp / "source.md"
@@ -60,6 +60,12 @@ def test_build_synthesis_outputs_expected_files():
 
         note1 = {
             "batch_id": "batch-001",
+            "batch_key": "giant-guide-chapter-a-b01",
+            "batch_hash": json.loads(
+                (run_dir / "batch-notes" / "giant-guide-chapter-a-b01.json").read_text(
+                    encoding="utf-8"
+                )
+            )["batch_hash"],
             "status": "completed",
             "summary": "Chapter A introduces Alpha and Beta.",
             "key_claims": ["Alpha and Beta are paired concepts."],
@@ -72,6 +78,12 @@ def test_build_synthesis_outputs_expected_files():
         }
         note2 = {
             "batch_id": "batch-002",
+            "batch_key": "giant-guide-chapter-b-b01",
+            "batch_hash": json.loads(
+                (run_dir / "batch-notes" / "giant-guide-chapter-b-b01.json").read_text(
+                    encoding="utf-8"
+                )
+            )["batch_hash"],
             "status": "completed",
             "summary": "Chapter B introduces Gamma as a follow-up topic.",
             "key_claims": ["Gamma extends the earlier flow."],
@@ -82,10 +94,10 @@ def test_build_synthesis_outputs_expected_files():
             "cross_refs": ["guide-topic-a1.md"],
             "candidate_topics": ["Gamma", "Alpha"],
         }
-        (run_dir / "batch-notes" / "batch-001.json").write_text(
+        (run_dir / "batch-notes" / "giant-guide-chapter-a-b01.json").write_text(
             json.dumps(note1, ensure_ascii=False, indent=2), encoding="utf-8"
         )
-        (run_dir / "batch-notes" / "batch-002.json").write_text(
+        (run_dir / "batch-notes" / "giant-guide-chapter-b-b01.json").write_text(
             json.dumps(note2, ensure_ascii=False, indent=2), encoding="utf-8"
         )
 
@@ -97,9 +109,30 @@ def test_build_synthesis_outputs_expected_files():
         assert (out_dir / "topic-candidates.md").exists()
         assert (out_dir / "glossary-seeds.md").exists()
         assert (out_dir / "unresolved-questions.md").exists()
-        assert (out_dir / "synthesis-report.json").exists()
+        assert (out_dir / "candidate-link-map.md").exists()
+        assert (out_dir / "candidate-link-map.json").exists()
+        assert (out_dir / "candidate-pages" / "overview-giant-guide.md").exists()
+        assert (
+            out_dir / "candidate-pages" / "knowledge-giant-guide-chapter-a.md"
+        ).exists()
+        assert (out_dir / "candidate-pages" / "knowledge-alpha.md").exists()
 
         overview = (out_dir / "source-overview.md").read_text(encoding="utf-8")
-        topics = (out_dir / "topic-candidates.md").read_text(encoding="utf-8")
-        assert "Giant Guide" in overview
-        assert "Alpha" in topics
+        chapter_page = (
+            out_dir / "candidate-pages" / "knowledge-giant-guide-chapter-a.md"
+        ).read_text(encoding="utf-8")
+        topic_page = (out_dir / "candidate-pages" / "knowledge-alpha.md").read_text(
+            encoding="utf-8"
+        )
+        link_map = json.loads(
+            (out_dir / "candidate-link-map.json").read_text(encoding="utf-8")
+        )
+
+        assert "candidate-pages/overview-giant-guide.md" in overview
+        assert "knowledge-alpha.md" in chapter_page
+        assert "knowledge-giant-guide-chapter-a.md" in topic_page
+        assert "overview-giant-guide.md" == link_map["overview_page"]
+        assert (
+            "knowledge-alpha.md"
+            in link_map["pages"]["knowledge-giant-guide-chapter-a.md"]["links"]
+        )

--- a/tests/test_synthesize_knowledge.py
+++ b/tests/test_synthesize_knowledge.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""Tests for synthesize_knowledge.py script."""
+
+import sys
+import json
+import tempfile
+from pathlib import Path
+
+# Add scripts directory to path
+scripts_dir = (
+    Path(__file__).parent.parent / "skills" / "knowledge-base-ingest" / "scripts"
+)
+sys.path.insert(0, str(scripts_dir))
+
+from close_read_markdown import prepare_run  # noqa: E402
+from synthesize_knowledge import build_synthesis  # noqa: E402
+
+
+def make_source(path: Path) -> None:
+    path.write_text(
+        """# Giant Guide
+
+## Chapter A
+
+### Topic A1
+
+Alpha flow. Alpha flow. Alpha flow.
+
+### Topic A2
+
+Beta flow. Beta flow. Beta flow.
+
+## Chapter B
+
+### Topic B1
+
+Gamma flow. Gamma flow. Gamma flow.
+""",
+        encoding="utf-8",
+    )
+
+
+def test_build_synthesis_outputs_expected_files():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        source = tmp / "source.md"
+        run_dir = tmp / "run"
+        out_dir = run_dir / "synthesis"
+        make_source(source)
+
+        prepare_run(
+            source=source,
+            out_dir=run_dir,
+            level=2,
+            max_chunk_words=60,
+            max_batch_words=40,
+            max_chunks_per_batch=2,
+            prefix="guide-",
+        )
+
+        note1 = {
+            "batch_id": "batch-001",
+            "status": "completed",
+            "summary": "Chapter A introduces Alpha and Beta.",
+            "key_claims": ["Alpha and Beta are paired concepts."],
+            "concepts": ["Alpha", "Beta"],
+            "procedures": ["Review Topic A1 before Topic A2"],
+            "entities": ["Giant Guide"],
+            "open_questions": ["How is Gamma related?"],
+            "cross_refs": ["guide-topic-b1.md"],
+            "candidate_topics": ["Alpha", "Beta"],
+        }
+        note2 = {
+            "batch_id": "batch-002",
+            "status": "completed",
+            "summary": "Chapter B introduces Gamma as a follow-up topic.",
+            "key_claims": ["Gamma extends the earlier flow."],
+            "concepts": ["Gamma", "Alpha"],
+            "procedures": ["Compare Gamma with Alpha"],
+            "entities": ["Giant Guide"],
+            "open_questions": [],
+            "cross_refs": ["guide-topic-a1.md"],
+            "candidate_topics": ["Gamma", "Alpha"],
+        }
+        (run_dir / "batch-notes" / "batch-001.json").write_text(
+            json.dumps(note1, ensure_ascii=False, indent=2), encoding="utf-8"
+        )
+        (run_dir / "batch-notes" / "batch-002.json").write_text(
+            json.dumps(note2, ensure_ascii=False, indent=2), encoding="utf-8"
+        )
+
+        report = build_synthesis(run_dir, out_dir)
+
+        assert report["completed_notes"] == 2
+        assert (out_dir / "source-overview.md").exists()
+        assert (out_dir / "chapter-summaries.md").exists()
+        assert (out_dir / "topic-candidates.md").exists()
+        assert (out_dir / "glossary-seeds.md").exists()
+        assert (out_dir / "unresolved-questions.md").exists()
+        assert (out_dir / "synthesis-report.json").exists()
+
+        overview = (out_dir / "source-overview.md").read_text(encoding="utf-8")
+        topics = (out_dir / "topic-candidates.md").read_text(encoding="utf-8")
+        assert "Giant Guide" in overview
+        assert "Alpha" in topics

--- a/tests/test_synthesize_knowledge.py
+++ b/tests/test_synthesize_knowledge.py
@@ -148,3 +148,14 @@ def test_build_synthesis_outputs_candidate_pages_and_link_map():
             in link_map["pages"]["knowledge-giant-guide-chapter-a.md"]["links"]
         )
         assert report["candidate_metadata"]["default_area"] == "learning"
+
+        # Re-run synthesis with Gamma removed and ensure stale candidate pages are cleaned up.
+        note2["status"] = "pending"
+        note2["summary"] = ""
+        note2["concepts"] = []
+        note2["candidate_topics"] = []
+        (run_dir / "batch-notes" / "giant-guide-chapter-b-b01.json").write_text(
+            json.dumps(note2, ensure_ascii=False, indent=2), encoding="utf-8"
+        )
+        build_synthesis(run_dir, out_dir, default_area="learning")
+        assert not (out_dir / "candidate-pages" / "knowledge-gamma.md").exists()

--- a/tests/test_synthesize_knowledge.py
+++ b/tests/test_synthesize_knowledge.py
@@ -101,7 +101,9 @@ def test_build_synthesis_outputs_candidate_pages_and_link_map():
             json.dumps(note2, ensure_ascii=False, indent=2), encoding="utf-8"
         )
 
-        report = build_synthesis(run_dir, out_dir)
+        report = build_synthesis(
+            run_dir, out_dir, default_area="learning", owner="Codex", status="draft"
+        )
 
         assert report["completed_notes"] == 2
         assert (out_dir / "source-overview.md").exists()
@@ -118,6 +120,9 @@ def test_build_synthesis_outputs_candidate_pages_and_link_map():
         assert (out_dir / "candidate-pages" / "knowledge-alpha.md").exists()
 
         overview = (out_dir / "source-overview.md").read_text(encoding="utf-8")
+        overview_page = (
+            out_dir / "candidate-pages" / "overview-giant-guide.md"
+        ).read_text(encoding="utf-8")
         chapter_page = (
             out_dir / "candidate-pages" / "knowledge-giant-guide-chapter-a.md"
         ).read_text(encoding="utf-8")
@@ -129,10 +134,17 @@ def test_build_synthesis_outputs_candidate_pages_and_link_map():
         )
 
         assert "candidate-pages/overview-giant-guide.md" in overview
+        assert 'type: "overview"' in overview_page
+        assert 'area: "learning"' in overview_page
+        assert "candidate: true" in overview_page
+        assert 'owner: "Codex"' in overview_page
         assert "knowledge-alpha.md" in chapter_page
+        assert 'type: "knowledge"' in chapter_page
+        assert 'status: "draft"' in chapter_page
         assert "knowledge-giant-guide-chapter-a.md" in topic_page
         assert "overview-giant-guide.md" == link_map["overview_page"]
         assert (
             "knowledge-alpha.md"
             in link_map["pages"]["knowledge-giant-guide-chapter-a.md"]["links"]
         )
+        assert report["candidate_metadata"]["default_area"] == "learning"


### PR DESCRIPTION
## What changed

- adds a close-reading harness for oversized markdown sources in `knowledge-base-ingest`
- adds changed-batches-only reruns using source/chunk/batch hashes so unchanged completed notes can be preserved
- adds synthesis outputs for candidate pages, candidate link maps, and candidate draft pages with frontmatter
- updates ingest docs, prompts, and guidance to describe close-reading mode, incremental reruns, and draft candidate outputs
- adds tests covering close-reading preparation, rerun behavior, stale artifact cleanup, synthesis outputs, and frontmatter generation

## Why it changed

The previous ingest flow could split large markdown sources, but it was still too shallow for very large books or handbooks. This branch turns oversized-source ingest into a resumable reading harness so the AI can:

- read in batches instead of one pass
- preserve rolling context between batches
- rerun only changed portions after source edits
- generate candidate wiki pages and link structure that are closer to real vault pages

## User / developer impact

- oversized markdown imports are now much more practical to iterate on
- completed notes from unchanged batches survive reruns
- synthesis artifacts are closer to directly usable wiki drafts because candidate pages now include draft frontmatter and source metadata
- candidate link outputs make final landing into the vault less manual

## Root cause / fix

A careful validation pass found a real issue: when batches were removed, stale packet files could remain and leave broken relative links. This branch fixes that by cleaning inactive packet files on rerun and clearing stale candidate pages before synthesis rewrite.

## Suggested review order

1. `skills/knowledge-base-ingest/scripts/close_read_markdown.py`
2. `skills/knowledge-base-ingest/scripts/synthesize_knowledge.py`
3. `tests/test_close_read_markdown.py` + `tests/test_synthesize_knowledge.py`
4. `skills/knowledge-base-ingest/SKILL.md` and the ingest docs

## Validation

- `python3 -m py_compile skills/knowledge-base-ingest/scripts/close_read_markdown.py skills/knowledge-base-ingest/scripts/synthesize_knowledge.py`
- `black --check skills/knowledge-base-ingest/scripts/close_read_markdown.py skills/knowledge-base-ingest/scripts/synthesize_knowledge.py tests/test_close_read_markdown.py tests/test_synthesize_knowledge.py`
- `flake8 --max-line-length=120 --ignore=E501,W503 skills/knowledge-base-ingest/scripts/close_read_markdown.py skills/knowledge-base-ingest/scripts/synthesize_knowledge.py tests/test_close_read_markdown.py tests/test_synthesize_knowledge.py`
- `pytest -q`
- extra sandbox validation for:
  - unchanged reruns
  - changed-batches-only reruns
  - removed-batch cleanup
  - candidate page frontmatter generation
  - generated relative-link integrity
