### PR TITLE
ux: clarify Obsidian install and detect scripts

### DIFF
--- a/skills/knowledge-base-orchestrator/scripts/detect-obsidian.sh
+++ b/skills/knowledge-base-orchestrator/scripts/detect-obsidian.sh
@@ -5,8 +5,11 @@
 
 set -e
 
-echo "正在检测 Obsidian（黑曜石笔记软件）..."
-echo "Detecting Obsidian..."
+echo "=========================================="
+echo "🔍 正在检测 Obsidian（黑曜石笔记软件）"
+echo "   注意：此脚本仅检测是否已安装，不会自动安装"
+echo "   Note: This script only detects installation status"
+echo "=========================================="
 
 # 检测操作系统 (Detect OS)
 OS="$(uname -s)"

--- a/skills/knowledge-base-orchestrator/scripts/install-obsidian.sh
+++ b/skills/knowledge-base-orchestrator/scripts/install-obsidian.sh
@@ -9,8 +9,11 @@ set -e
 log_warn() { echo "⚠️  $1"; }
 log_info() { echo "ℹ️  $1"; }
 
-echo "正在安装 Obsidian（黑曜石笔记软件）..."
-echo "Installing Obsidian..."
+echo "=========================================="
+echo "📦 正在安装 Obsidian（黑曜石笔记软件）"
+echo "   此脚本将下载并安装 Obsidian 到您的系统"
+echo "   This script will download and install Obsidian"
+echo "=========================================="
 
 # 检测操作系统 (Detect OS)
 OS="$(uname -s)"


### PR DESCRIPTION
## Summary
- clarify that detect-obsidian.sh only checks installation status
- clarify that install-obsidian.sh will actually download and install Obsidian
- keep the current main behavior while making the user-facing messaging clearer

## Testing
- not run (script messaging change only)