### PR TITLE
chore: add dev requirements and align vault profile contracts

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,6 @@
+# Development dependencies for wiki-knowledgebase-share-kit
+# Install with: pip install -r requirements-dev.txt
+
+pytest>=7.0
+black>=23.0
+flake8>=6.0

--- a/skills/knowledge-base-audit/references/vault-profile-contract.md
+++ b/skills/knowledge-base-audit/references/vault-profile-contract.md
@@ -1,24 +1,28 @@
 # Vault Profile Contract
 
-## The audit skill needs these facts
+## A knowledge-base skill should not proceed without these facts
 - vault root path
-- content page directory
-- reader entrypoint
-- milestone log
-- maintainer entrypoint
+- markdown page directory
+- reader entrypoint file
+- milestone log file
+- maintainer entrypoint file
 - area list
 - root page map
 - canonical root-level markdown files
 - frontmatter contract
 
-## Why root-level canonical files matter
-The audit skill must know which markdown files are intentionally allowed at the vault root.
-Otherwise it cannot reliably report stray root-level markdown artifacts.
+## Why this matters
+Without a profile, the skill cannot safely decide:
+- where overview pages should live
+- which root page should own a chapter/topic page group
+- which files are allowed at the vault root
+- how imported pages should be tagged and typed
 
 ## If the profile is missing
-Ask for the minimum missing configuration before claiming something is invalid.
+Ask for the minimum missing configuration before editing files.
 Do not guess:
-- which pages are root pages
-- whether a markdown file belongs at the vault root
-- allowed area names
-- required metadata fields
+- root page filenames
+- area names
+- page directory layout
+- metadata fields
+- log policy

--- a/skills/knowledge-base-ingest/references/vault-profile-contract.md
+++ b/skills/knowledge-base-ingest/references/vault-profile-contract.md
@@ -1,6 +1,6 @@
 # Vault Profile Contract
 
-## The ingest skill should not proceed without these facts
+## A knowledge-base skill should not proceed without these facts
 - vault root path
 - markdown page directory
 - reader entrypoint file
@@ -12,7 +12,7 @@
 - frontmatter contract
 
 ## Why this matters
-Long-form ingestion creates many pages at once. Without a profile, the skill cannot safely decide:
+Without a profile, the skill cannot safely decide:
 - where overview pages should live
 - which root page should own a chapter/topic page group
 - which files are allowed at the vault root

--- a/skills/knowledge-base-maintenance/references/vault-profile-contract.md
+++ b/skills/knowledge-base-maintenance/references/vault-profile-contract.md
@@ -1,6 +1,6 @@
 # Vault Profile Contract
 
-## The skill should not proceed without these facts
+## A knowledge-base skill should not proceed without these facts
 - vault root path
 - markdown page directory
 - reader entrypoint file
@@ -11,22 +11,18 @@
 - canonical root-level markdown files
 - frontmatter contract
 
-## The fixed model this skill assumes
-- `project`
-- `knowledge`
-- `ops`
-- `task`
-- `overview`
+## Why this matters
+Without a profile, the skill cannot safely decide:
+- where overview pages should live
+- which root page should own a chapter/topic page group
+- which files are allowed at the vault root
+- how imported pages should be tagged and typed
 
 ## If the profile is missing
 Ask for the minimum missing configuration before editing files.
 Do not guess:
-- paths
 - root page filenames
 - area names
-- naming conventions
+- page directory layout
+- metadata fields
 - log policy
-
-## Why canonical root-level markdown files matter
-Audit and maintenance both need to know which markdown files are allowed at the vault root.
-Without this, stray-file checks become noisy and unreliable.


### PR DESCRIPTION
## Summary
- add a development requirements file for local contributor setup
- align the audit, ingest, and maintenance vault-profile contract docs
- keep only the portions of the original branch that still improve main without regressing newer work

## Testing
- not run (docs/config-only change)