### PR TITLE
docs: add OpenClaw/Hermes agent runtime write-back patterns

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -7,7 +7,7 @@
 [![Contributors](https://img.shields.io/github/contributors/zouxy111/wiki-knowledgebase-share-kit)](https://github.com/zouxy111/wiki-knowledgebase-share-kit/graphs/contributors)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](./LICENSE)
 
-> An **8-skill knowledge-base package** for markdown / wiki / Obsidian-style vaults.
+> An **8-skill knowledge-base governance and collaboration kit** for markdown / wiki / Obsidian-style vaults.
 > The goal is not to record more logs, but to keep a vault **navigable, role-stable, maintainable, collaboration-friendly, and auditable**.
 
 <p align="center">
@@ -296,6 +296,9 @@ But the important boundary is:
 - these are **recommended combinations**, not exclusive dependencies
 - the core value of this repository is still **knowledge-base structure governance and workflow design**, not platform lock-in
 
+If you want to plug the method into a longer-running OpenClaw / Hermes workspace, continue with [`docs/agent-runtime-writeback-patterns.md`](./docs/agent-runtime-writeback-patterns.md).
+That document explains why we recommend an optional `agent-workspace/` folder parallel to `pages/`, so drafts, distills, and runtime helper artifacts have a home without polluting durable knowledge pages.
+
 ---
 
 ## Quick start
@@ -336,6 +339,9 @@ A: Usually the repo is fine; the runtime's actual skills directory was not insta
 **Q: How do I prevent a huge source from being only half-read and still being reported as “fully imported”?**
 A: Do not feed the whole giant source directly to the model. First generate `manifest.json` and `coverage-map.md` with `split_markdown.py`, process the source chunk by chunk, then gate completion with `verify_ingest_coverage.py`. See [`docs/ingest-completeness-guardrails.md`](./docs/ingest-completeness-guardrails.md).
 
+**Q: Can these distilled outputs also be written back into OpenClaw?**
+A: Yes. The recommended pattern is to keep `pages/` for durable knowledge and add an optional `agent-workspace/` folder parallel to it for OpenClaw / Hermes drafts, shared-project mirrors, distills, and intermediate comparison notes. See [`docs/agent-runtime-writeback-patterns.md`](./docs/agent-runtime-writeback-patterns.md).
+
 **Q: Are enterprise and medical separate solutions?**
 A: No. They are two common variants of the same broader scenario: high-knowledge-density, multi-person, auditable collaboration.
 
@@ -351,6 +357,7 @@ A: It should not. The intended use is to keep collaboration-relevant stable sign
 - `templates/vault-profile-template.md`
 - `docs/example-prompts.md`
 - `docs/usage-sop.md`
+- `docs/agent-runtime-writeback-patterns.md`
 - `examples/case-study-pathology-ingest-iteration.md`
 
 ---

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Contributors](https://img.shields.io/github/contributors/zouxy111/wiki-knowledgebase-share-kit)](https://github.com/zouxy111/wiki-knowledgebase-share-kit/graphs/contributors)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](./LICENSE)
 
-> 一套面向 markdown / wiki / Obsidian-style vault 的 **8-skill 知识库维护包**。
+> 一套面向 markdown / wiki / Obsidian-style vault 的 **8-skill 知识库治理与协作接入包**。
 > 目标不是堆更多日志，而是把知识库收敛成：**入口清楚、页面角色稳定、长期可维护、对协作友好、可审计**。
 
 <p align="center">
@@ -318,6 +318,9 @@ cp -r skills/work-journal ~/.codex/skills/
 - 这些平台/工具是**推荐组合**，不是本仓库唯一依赖
 - 本仓库的核心价值仍然是 **知识库结构治理与 workflow 设计**，不是平台绑定
 
+如果你准备把这套方法接到 OpenClaw / Hermes 的长期工作区里，建议继续看 [`docs/agent-runtime-writeback-patterns.md`](./docs/agent-runtime-writeback-patterns.md)。
+那份文档会专门说明：为什么推荐保留一个与 `pages/` 并行的可选 `agent-workspace/` 目录，用来承接草稿、蒸馏和 runtime 辅助产物，而不污染稳定知识页。
+
 ---
 
 ## 快速上手
@@ -358,6 +361,9 @@ A：通常不是 repo 缺 skill，而是**当前运行平台的 skills 目录没
 **Q：怎么防止长文档只读前半部分就被误判为“已完整导入”？**
 A：不要直接把超长 source 整篇塞给模型。先运行 `split_markdown.py` 生成 `manifest.json` 和 `coverage-map.md`，逐 chunk 处理，再用 `verify_ingest_coverage.py` 做完成态校验；详见 [`docs/ingest-completeness-guardrails.md`](./docs/ingest-completeness-guardrails.md)。
 
+**Q：这些蒸馏结果也能写进 OpenClaw 吗？**
+A：能。推荐把 `pages/` 留给稳定知识，再保留一个与 `pages/` 并行的可选 `agent-workspace/` 目录，承接 OpenClaw / Hermes 的草稿、shared project 副本、distill 产物和中间对照表；详见 [`docs/agent-runtime-writeback-patterns.md`](./docs/agent-runtime-writeback-patterns.md)。
+
 **Q：企业和医疗是不是两套完全不同的方案？**
 A：不是。它们都属于“高知识密度 + 多人协作 + 可审计”的场景，只是资料类型和协作方式不同。
 
@@ -373,6 +379,7 @@ A：不应该。正确做法是只保留协作相关的稳定信号，并明确 
 - `templates/vault-profile-template.md`
 - `docs/example-prompts.md`
 - `docs/usage-sop.md`
+- `docs/agent-runtime-writeback-patterns.md`
 - `examples/case-study-pathology-ingest-iteration.md`
 
 ---

--- a/START-HERE.md
+++ b/START-HERE.md
@@ -225,6 +225,8 @@ Include timestamps, project associations, meeting notes, and weekly distillation
 2. `templates/vault-profile-template.md`
 3. `docs/usage-sop.md`
 4. `docs/example-prompts.md`
+5. `docs/collaboration-integration-patterns.md`
+6. `docs/agent-runtime-writeback-patterns.md`
 
 ---
 
@@ -241,5 +243,7 @@ Include timestamps, project associations, meeting notes, and weekly distillation
 1. `docs/customization-guide.md`
 2. `docs/usage-sop.md`
 3. `docs/example-prompts.md`
-4. `examples/case-study-pathology-ingest-iteration.md`
-5. `examples/scenario-*.md`（注意：这些是场景化示意）
+4. `docs/collaboration-integration-patterns.md`
+5. `docs/agent-runtime-writeback-patterns.md`
+6. `examples/case-study-pathology-ingest-iteration.md`
+7. `examples/scenario-*.md`（注意：这些是场景化示意）

--- a/docs/agent-runtime-writeback-patterns.md
+++ b/docs/agent-runtime-writeback-patterns.md
@@ -61,6 +61,8 @@
 - `members/<id>/questionnaire.md`
 - `members/<id>/response.md`
 - `members/<id>/assignment.md`
+- `members/<id>/progress-update.md`
+- `members/<id>/decision-distill.md`
 - `coordination/alignment-summary.md`
 - `coordination/task-board.md`
 - `coordination/decision-register.md`
@@ -97,11 +99,15 @@ my-vault/
   log.md
   pages/
     ... stable knowledge pages ...
+  team-project/
+    project-brief.md
+    team-roster.md
+    members/
+    coordination/
   agent-workspace/
     drafts/
     distills/
     imports/
-    shared-projects/
     openclaw/
       prompts/
       scratch/
@@ -112,11 +118,12 @@ my-vault/
 
 说明：
 - `pages/` 继续只放稳定知识页
+- `team-project/` 才是正式 shared project directory，也是 coordinator workflow 的唯一事实源
 - `agent-workspace/` 是**可选增强层**，不是强制 schema
-- `shared-projects/` 可以只是本地镜像、辅助材料或待同步版本
 - 真正进入 coordinator 闭环的，仍应以正式 shared project directory 为准
+- 如果确实需要本地镜像，建议明确标成只读 cache，并避免把它当成协调事实源
 
-如果你的团队已经把 `team-project/` 放在 NAS / 网盘同步目录里，那么 `agent-workspace/shared-projects/` 也可以不保留，或只保留本地辅助副本。
+如果你的团队已经把 `team-project/` 放在 NAS / 网盘同步目录里，那么 `agent-workspace/` 就更适合作为纯草稿 / distill / runtime helper 区，而不是再维护一份可写的 shared project 副本。
 
 ---
 

--- a/docs/agent-runtime-writeback-patterns.md
+++ b/docs/agent-runtime-writeback-patterns.md
@@ -1,0 +1,223 @@
+# Agent Runtime Write-back Patterns
+
+> 这份文档专门解释：如果你把这套 share kit 跑在 OpenClaw、Hermes 或其他 agent runtime 上，哪些内容应该写回共享项目目录 / wiki，哪些内容应该先落在 agent 自己的辅助工作区，以及为什么推荐保留一个与 `pages/` 并行的可选目录。
+
+---
+
+## 1. 先给严格结论
+
+**能，OpenClaw 也可以承接这套写回模式。**
+
+但正确做法不是把所有 agent 产物直接塞进 `pages/`，而是把写回目标分成三层：
+1. **稳定知识层**：`pages/`
+2. **共享协作事实层**：`team-project/` 或其它 shared project directory
+3. **agent 辅助工作层**：一个与 `pages/` 并行的可选目录，例如 `agent-workspace/`
+
+这第三层不是新的强制 schema，也不是 coordinator 的事实源；它只是一个**干净的缓冲层**，用来接住 OpenClaw / Hermes 的草稿、蒸馏、中间对照表、批处理产物和 runtime 辅助材料。
+
+---
+
+## 2. 为什么推荐保留一个与 `pages/` 并行的目录
+
+如果没有这个缓冲层，最常见的问题就是：
+- 草稿直接混进稳定知识页
+- session 过程噪音回流到 wiki
+- runtime 特有的中间文件无处安放
+- 成员各自用 agent 并行工作时，临时材料和正式事实边界不清
+
+所以更稳妥的做法是：
+
+> **让 `pages/` 继续只负责稳定知识，让一个与 `pages/` 并行的可选目录负责 agent 的工作过程与中间产物。**
+
+这样做的好处：
+- 不破坏现有 `pages/` 契约
+- 不把 OpenClaw / Hermes 的平台细节硬写进公共模板
+- 给草稿 / distill / imports / 对照表一个明确落点
+- 更适合多人并行，再按规则提升为正式知识或正式协作事实
+
+---
+
+## 3. 推荐的三层写回模型
+
+### A. `pages/`：稳定知识层
+这里放：
+- `knowledge` 页面
+- `ops` 页面
+- `project` 导航页
+- `task` 页面
+- `overview` 页面
+- 经确认后可长期复用的稳定知识
+
+这里**不应该**直接堆：
+- session 原始流水
+- 大量补问草稿
+- 临时对照表
+- 未确认的多人协调中间态
+
+### B. `team-project/`：共享协作事实层
+这里放：
+- `project-brief.md`
+- `team-roster.md`
+- `members/<id>/questionnaire.md`
+- `members/<id>/response.md`
+- `members/<id>/assignment.md`
+- `coordination/alignment-summary.md`
+- `coordination/task-board.md`
+- `coordination/decision-register.md`
+
+它的职责是：
+- 承接 coordinator workflow
+- 保持 draft / approved / superseded / blocked 边界
+- 作为多人协作时的唯一事实源
+
+### C. `agent-workspace/`：runtime 辅助工作层（可选但推荐）
+这里可以放：
+- drafts
+- distills
+- imports
+- intermediate comparison notes
+- local helper checklists
+- runtime-specific scratch files
+- 需要稍后再提升的候选材料
+
+这一层的定位是：
+- **帮助 OpenClaw / Hermes 并行工作**
+- **隔离过程噪音**
+- **为后续 promotion 做准备**
+
+它不是本仓库的公共硬契约；没有它也能跑，只是更容易把过程噪音混回稳定知识层。
+
+---
+
+## 4. 推荐目录示意（可选模式，不是强制模板）
+
+```text
+my-vault/
+  index.md
+  log.md
+  pages/
+    ... stable knowledge pages ...
+  agent-workspace/
+    drafts/
+    distills/
+    imports/
+    shared-projects/
+    openclaw/
+      prompts/
+      scratch/
+    hermes/
+      session-notes/
+      promoted-skills/
+```
+
+说明：
+- `pages/` 继续只放稳定知识页
+- `agent-workspace/` 是**可选增强层**，不是强制 schema
+- `shared-projects/` 可以只是本地镜像、辅助材料或待同步版本
+- 真正进入 coordinator 闭环的，仍应以正式 shared project directory 为准
+
+如果你的团队已经把 `team-project/` 放在 NAS / 网盘同步目录里，那么 `agent-workspace/shared-projects/` 也可以不保留，或只保留本地辅助副本。
+
+---
+
+## 5. OpenClaw 怎么接这个写回模式
+
+OpenClaw 这类 runtime 很适合承接：
+- 日常多入口资料收集
+- 共享项目目录驱动的 coordinator workflow
+- 基于 skills / prompts / workspace 的持续工作流
+
+因此，推荐把它理解成：
+- **一个可以驱动 shared project directory 的运行平台**
+- **一个可以承接 `agent-workspace/` 的个人工作面**
+- **一个可以沉淀可复用 procedural pattern 的 skill 运行面**
+
+更实际地说，OpenClaw 侧通常可以写回三类东西：
+1. 写回 shared project directory 中需要正式进入协作闭环的 markdown 文件
+2. 写回 `agent-workspace/` 中的草稿、distill、中间产物
+3. 把反复出现的稳定操作方法沉淀为更可复用的 prompts / skills / runbook 说明
+
+### 边界
+不要把下面这些内容直接当成稳定知识：
+- 原始 chat transcript
+- 尚未确认的补问草稿
+- 平台专有调试痕迹
+- 一次性临时判断过程
+
+这些内容更适合先留在 `agent-workspace/`，再决定是否提升进 `pages/` 或 shared project directory。
+
+---
+
+## 6. Hermes 怎么接这个写回模式
+
+Hermes 更适合承接另一类“长期沉淀”：
+- 协作相关的稳定记忆
+- 可反复复用的 procedural memory
+- 经过筛选的 distill
+- 长期会继续用到的 skill 化方法
+
+所以 Hermes 更像：
+- **长期记忆与技能提升层**
+- **重复工作模式的压缩层**
+- **更适合做持续自进化的 agent 面**
+
+但即便如此，Hermes 也不应该绕开 shared project directory 的事实边界。
+多人协作里，正式事实仍应回到：
+- `team-project/`
+- `pages/`
+- 已批准的 knowledge-base sync 目标
+
+而不是散落在 runtime 自己的内部状态里。
+
+---
+
+## 7. 一个简单可执行的 promotion 规则
+
+推荐按下面的顺序判断：
+
+### 先放进 `agent-workspace/`
+适用于：
+- 草稿
+- 待确认补问
+- session distill 初稿
+- 中间对照表
+- imports / packets / temporary synthesis
+
+### 再放进 shared project directory
+适用于：
+- 已进入协作闭环的问题、回答、对齐摘要、任务草案、决策草案
+- 需要让 coordinator 和所有成员共同读取的项目事实
+
+### 最后提升进 `pages/` 或知识库同步面
+适用于：
+- 已确认、稳定、跨项目可复用的知识
+- 稳定 runbook / ops 结论
+- 经过批准的长期决策规则
+- working profile 的稳定增量
+
+一句话：
+
+> **先把过程留在 `agent-workspace/`，把协作事实留在 shared project directory，把真正稳定的内容再提升进 `pages/`。**
+
+---
+
+## 8. 这不会改变核心公开契约
+
+这份文档描述的是：
+- 一个**推荐接入模式**
+- 一个**更稳的运行习惯**
+- 一个**与 `pages/` 并行的可选辅助目录**
+
+它**不会**改变本仓库的核心公开契约：
+- `pages/` 的角色模型不变
+- `team-project/` 的模板契约不变
+- `questionnaire / response / assignment / progress-update / decision-distill` 契约不变
+- OpenClaw / Hermes 仍然是推荐平台，而不是强依赖平台
+
+---
+
+## 9. 对外最推荐怎么讲
+
+如果你要向陌生用户解释，最稳妥的一句话是：
+
+> 这套 share kit 可以跑在 OpenClaw、Hermes 或其他兼容 runtime 上；推荐把 `pages/` 保持为稳定知识层，再保留一个与 `pages/` 并行的可选 `agent-workspace/` 目录承接草稿、蒸馏和中间产物。这样既能让每个人用自己的 agent 并行工作，也不会破坏 shared project directory 和 wiki 的事实边界。

--- a/docs/collaboration-integration-patterns.md
+++ b/docs/collaboration-integration-patterns.md
@@ -7,7 +7,7 @@
 
 ## 1. 这份文档解决什么问题
 
-很多人已经能看懂这套仓库有 5 个 skills，但第一次真正落地多人协同时，仍会卡在这些问题：
+很多人已经能看懂这套仓库有 8 个 skills，但第一次真正落地多人协同时，仍会卡在这些问题：
 - OpenClaw / Hermes 到底是“兼容”还是“主推平台”？
 - 共享项目目录应该放在 NAS / 网盘里，还是直接嵌进共享 wiki？
 - 每个人能不能在自己的 wiki / 私有资料区里先整理内容？
@@ -81,6 +81,9 @@
 - 内容已是 `approved`
 
 时，稳定决策或成员画像增量才回写知识库。
+
+> 如果你已经准备把这套 workflow 接到 OpenClaw / Hermes 的长期工作区里，推荐继续读 [`docs/agent-runtime-writeback-patterns.md`](./agent-runtime-writeback-patterns.md)。
+> 那份文档进一步解释了：为什么建议保留一个与 `pages/` 并行的可选 `agent-workspace/` 目录，用来承接草稿、蒸馏和 runtime 辅助产物，而不把这些过程噪音直接混进稳定知识页。
 
 ---
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -1871,6 +1871,7 @@
           <h3 data-i18n="nextTitle">Open these next</h3>
           <ul data-i18n-html="nextList">
             <li><a href="https://github.com/zouxy111/wiki-knowledgebase-share-kit/blob/main/START-HERE.md">START-HERE.md</a></li>
+            <li><a href="https://github.com/zouxy111/wiki-knowledgebase-share-kit/blob/main/docs/agent-runtime-writeback-patterns.md">docs/agent-runtime-writeback-patterns.md</a></li>
             <li><a href="https://github.com/zouxy111/wiki-knowledgebase-share-kit/blob/main/GLOSSARY.md">GLOSSARY.md</a></li>
             <li><a href="https://github.com/zouxy111/wiki-knowledgebase-share-kit/blob/main/docs/example-prompts.md">docs/example-prompts.md</a></li>
             <li><a href="https://github.com/zouxy111/wiki-knowledgebase-share-kit/releases/latest">Latest release</a></li>
@@ -2024,7 +2025,7 @@
         ctaStart: "Go to START-HERE",
         nextLabel: "Next surfaces",
         nextTitle: "Open these next",
-        nextList: "<li><a href=\"https://github.com/zouxy111/wiki-knowledgebase-share-kit/blob/main/START-HERE.md\">START-HERE.md</a></li><li><a href=\"https://github.com/zouxy111/wiki-knowledgebase-share-kit/blob/main/GLOSSARY.md\">GLOSSARY.md</a></li><li><a href=\"https://github.com/zouxy111/wiki-knowledgebase-share-kit/blob/main/docs/example-prompts.md\">docs/example-prompts.md</a></li><li><a href=\"https://github.com/zouxy111/wiki-knowledgebase-share-kit/releases/latest\">Latest release</a></li><li><a href=\"https://github.com/zouxy111/wiki-knowledgebase-share-kit/issues\">Issues</a></li>",
+        nextList: "<li><a href=\"https://github.com/zouxy111/wiki-knowledgebase-share-kit/blob/main/START-HERE.md\">START-HERE.md</a></li><li><a href=\"https://github.com/zouxy111/wiki-knowledgebase-share-kit/blob/main/docs/agent-runtime-writeback-patterns.md\">docs/agent-runtime-writeback-patterns.md</a></li><li><a href=\"https://github.com/zouxy111/wiki-knowledgebase-share-kit/blob/main/GLOSSARY.md\">GLOSSARY.md</a></li><li><a href=\"https://github.com/zouxy111/wiki-knowledgebase-share-kit/blob/main/docs/example-prompts.md\">docs/example-prompts.md</a></li><li><a href=\"https://github.com/zouxy111/wiki-knowledgebase-share-kit/releases/latest\">Latest release</a></li><li><a href=\"https://github.com/zouxy111/wiki-knowledgebase-share-kit/issues\">Issues</a></li>",
         footerCopy: "Open source under MIT · Built by 邹星宇, 杨琦, and 张陈祎",
         footerRepo: "GitHub repo",
         footerReleases: "Releases",
@@ -2157,7 +2158,7 @@
         ctaStart: "前往 START-HERE",
         nextLabel: "下一步入口",
         nextTitle: "建议接着打开这些",
-        nextList: "<li><a href=\"https://github.com/zouxy111/wiki-knowledgebase-share-kit/blob/main/START-HERE.md\">START-HERE.md</a></li><li><a href=\"https://github.com/zouxy111/wiki-knowledgebase-share-kit/blob/main/GLOSSARY.md\">GLOSSARY.md</a></li><li><a href=\"https://github.com/zouxy111/wiki-knowledgebase-share-kit/blob/main/docs/example-prompts.md\">docs/example-prompts.md</a></li><li><a href=\"https://github.com/zouxy111/wiki-knowledgebase-share-kit/releases/latest\">最新版本</a></li><li><a href=\"https://github.com/zouxy111/wiki-knowledgebase-share-kit/issues\">Issues</a></li>",
+        nextList: "<li><a href=\"https://github.com/zouxy111/wiki-knowledgebase-share-kit/blob/main/START-HERE.md\">START-HERE.md</a></li><li><a href=\"https://github.com/zouxy111/wiki-knowledgebase-share-kit/blob/main/docs/agent-runtime-writeback-patterns.md\">docs/agent-runtime-writeback-patterns.md</a></li><li><a href=\"https://github.com/zouxy111/wiki-knowledgebase-share-kit/blob/main/GLOSSARY.md\">GLOSSARY.md</a></li><li><a href=\"https://github.com/zouxy111/wiki-knowledgebase-share-kit/blob/main/docs/example-prompts.md\">docs/example-prompts.md</a></li><li><a href=\"https://github.com/zouxy111/wiki-knowledgebase-share-kit/releases/latest\">最新版本</a></li><li><a href=\"https://github.com/zouxy111/wiki-knowledgebase-share-kit/issues\">Issues</a></li>",
         footerCopy: "MIT 开源 · 开发者：邹星宇、杨琦、张陈祎",
         footerRepo: "GitHub 仓库",
         footerReleases: "版本发布",


### PR DESCRIPTION
## Summary
- add a dedicated doc explaining how OpenClaw / Hermes can participate in write-back flows
- recommend an optional `agent-workspace/` folder parallel to `pages/` without changing the public contract
- surface the new doc from README, START-HERE, collaboration docs, and the HTML landing page

## Why
This makes it clearer for unfamiliar users that:
- OpenClaw can also receive distilled/project write-back outputs
- the recommended pattern is `pages/` for durable knowledge + `agent-workspace/` for drafts/distills/runtime helper artifacts
- this is a recommended integration mode, not a hard schema change
